### PR TITLE
make TimeZoneWarning more verbose

### DIFF
--- a/movingpandas/trajectory.py
+++ b/movingpandas/trajectory.py
@@ -136,6 +136,7 @@ class Trajectory:
             warnings.warn(
                 "Time zone information dropped from trajectory. "
                 "All dates and times will use local time. "
+                "This has been applied using df.tz_localize(None). "
                 "To use UTC or a different time zone, convert and drop "
                 "time zone information prior to trajectory creation.",
                 category=TimeZoneWarning,


### PR DESCRIPTION
I wasn't quite sure what "All dates and times will use local time" meant when I first encountered it so added a an extra line showing what operation is being applied.

cc. @bamacgabhann 

Now I think about this it may be worth creating an attribute such as orig_df_tz to keep track of the original df timezone before it is cast to none