### PR TITLE
GeoDataFrame to MF-JSON

### DIFF
--- a/movingpandas/io.py
+++ b/movingpandas/io.py
@@ -1,8 +1,109 @@
 import json
-
-from pandas import DataFrame
+from typing import Dict
 
 from movingpandas import Trajectory
+from geopandas import GeoDataFrame
+from pandas import DataFrame
+
+
+def gdf_to_mf_json(
+    gdf: GeoDataFrame,
+    traj_id_property: str,
+    datetime_column: str,
+    temporal_properties: list = None,
+    temporal_properties_static_fields: Dict[str, Dict] = None,
+    interpolation: str = None,
+    crs=None,
+    trs=None,
+) -> dict:
+    """
+    Converts a GeoDataFrame to a dictionary compatible with the Moving Features JSON (MF-JSON) specification.
+
+    Args:
+        gdf (GeoDataFrame): The input GeoDataFrame to convert.
+        traj_id_property (str): The name of the column in the GeoDataFrame that represents the trajectory identifier.
+        datetime_column (str): The name of the column in the GeoDataFrame that represents the datetime information.
+        temporal_properties (list, optional): A list of column names in the GeoDataFrame that represent additional temporal properties.
+                                               Defaults to None.
+        temporal_properties_static_fields (Dict[str, Dict], optional): A dictionary mapping column names to static fields associated with the
+                                                                      corresponding temporal property. One such static field is the unit of measurement (uom). Defaults to None.
+        interpolation (str, optional): The interpolation method used for the temporal geometry. Defaults to None.
+        crs (optional): Coordinate reference system for the MF-JSON. Defaults to None.
+        trs (optional): Temporal reference system for the MF-JSON. Defaults to None.
+
+    Returns:
+        dict: The MF-JSON representation of the GeoDataFrame.
+    """
+
+    if not isinstance(gdf, GeoDataFrame):
+        raise ValueError(
+            "Not a GeoDataFrame, but a {} was supplied. This function only works with GeoDataFrames.".format(
+                type(gdf)
+            )
+        )
+
+    if not temporal_properties:
+        temporal_properties = []
+
+    rows = []
+
+    for identifier, row in gdf.groupby(traj_id_property):
+        datetimes = row[datetime_column].tolist()
+        trajectory_data = {
+            "type": "Feature",
+            "properties": {
+                traj_id_property: identifier,
+                **row.drop(
+                    columns=[
+                        "geometry",
+                        datetime_column,
+                        traj_id_property,
+                        *temporal_properties,
+                    ]
+                ).to_dict(orient="records")[0],
+            },
+            "temporalGeometry": {
+                "type": "MovingPoint",
+                "coordinates": list(zip(row.geometry.x, row.geometry.y)),
+                "datetimes": datetimes,
+            },
+        }
+
+        if interpolation:
+            trajectory_data["temporalGeometry"]["interpolation"] = interpolation
+
+        if crs:
+            trajectory_data["crs"] = crs
+
+        if trs:
+            trajectory_data["trs"] = trs
+
+        if temporal_properties:
+            temporal_properties_data = _encode_temporal_properties(
+                datetimes, row, temporal_properties, temporal_properties_static_fields
+            )
+
+            trajectory_data["temporalProperties"] = [temporal_properties_data]
+
+        # Appending each trajectory data to the list of rows
+        rows.append(trajectory_data)
+
+    return {"type": "FeatureCollection", "features": rows}
+
+
+def _encode_temporal_properties(datetimes, row, temporal_properties, temporal_properties_static_fields):
+    temporal_properties_data = {
+        "datetimes": datetimes,
+    }
+    for prop in temporal_properties:
+        temporal_properties_data[prop] = {
+            "values": row[prop].tolist(),
+        }
+        if prop in (temporal_properties_static_fields or {}):
+            temporal_properties_data[prop].update(
+                temporal_properties_static_fields[prop]
+            )
+    return temporal_properties_data
 
 
 def read_mf_json(json_file_path, traj_id_property=None, traj_id=0):

--- a/movingpandas/io.py
+++ b/movingpandas/io.py
@@ -1,9 +1,10 @@
 import json
 from typing import Callable, Dict
 
-from movingpandas import Trajectory
 from geopandas import GeoDataFrame
 from pandas import DataFrame
+
+from movingpandas import Trajectory
 
 
 def gdf_to_mf_json(
@@ -24,17 +25,17 @@ def gdf_to_mf_json(
         gdf (GeoDataFrame): The input GeoDataFrame to convert.
         traj_id_property (str): The name of the column in the GeoDataFrame that represents the trajectory identifier.
         datetime_column (str): The name of the column in the GeoDataFrame that represents the datetime information.
-        temporal_properties (list, optional): A list of column names in the GeoDataFrame that represent additional temporal properties.
-                                               Defaults to None.
-        temporal_properties_static_fields (Dict[str, Dict], optional): A dictionary mapping column names to static fields associated with the
-                                                                      corresponding temporal property. One such static field is the unit of measurement (uom). Defaults to None.
+        temporal_properties (list, optional): A list of column names in the GeoDataFrame that represent additional
+            temporal properties. Defaults to None.
+        temporal_properties_static_fields (Dict[str, Dict], optional): A dictionary mapping column names to static
+            fields associated with the corresponding temporal property. Defaults to None.
         interpolation (str, optional): The interpolation method used for the temporal geometry. Defaults to None.
         crs (optional): Coordinate reference system for the MF-JSON. Defaults to None.
         trs (optional): Temporal reference system for the MF-JSON. Defaults to None.
-        datetime_encoder (Callable[[any], str|int], optional): A function that encodes the datetime values in the GeoDataFrame to a string ( IETF RFC 3339 ) or integer ( Timestamp, milliseconds ). Defaults to None.
-
+        datetime_encoder (Callable[[any], str|int], optional): A function that encodes the datetime values in the
+            GeoDataFrame to a string ( IETF RFC 3339 ) or integer ( Timestamp, milliseconds ). Defaults to None.
     Returns:
-        dict: The MF-JSON representation of the GeoDataFrame.
+        dict: The MF-JSON representation of the GeoDataFrame as a dictionary.
     """
 
     if not isinstance(gdf, GeoDataFrame):
@@ -108,7 +109,9 @@ def _retrieve_datetimes_from_row(datetime_column, datetime_encoder, row):
     return datetimes
 
 
-def _encode_temporal_properties(datetimes, row, temporal_properties, temporal_properties_static_fields):
+def _encode_temporal_properties(
+    datetimes, row, temporal_properties, temporal_properties_static_fields
+):
     temporal_properties_data = {
         "datetimes": datetimes,
     }

--- a/movingpandas/io.py
+++ b/movingpandas/io.py
@@ -19,21 +19,27 @@ def gdf_to_mf_json(
     datetime_encoder: Callable[[any], str | int] = None,
 ) -> dict:
     """
-    Converts a GeoDataFrame to a dictionary compatible with the Moving Features JSON (MF-JSON) specification.
+    Converts a GeoDataFrame to a dictionary compatible with the Moving Features JSON
+    (MF-JSON) specification.
 
     Args:
         gdf (GeoDataFrame): The input GeoDataFrame to convert.
-        traj_id_column (str): The name of the column in the GeoDataFrame that represents the trajectory identifier.
-        datetime_column (str): The name of the column in the GeoDataFrame that represents the datetime information.
-        temporal_columns (list, optional): A list of column names in the GeoDataFrame that represent additional
-            temporal properties. Defaults to None.
-        temporal_columns_static_fields (Dict[str, Dict], optional): A dictionary mapping column names to static
-            fields associated with the corresponding temporal property. Defaults to None.
-        interpolation (str, optional): The interpolation method used for the temporal geometry. Defaults to None.
+        traj_id_column (str): The name of the column in the GeoDataFrame that
+            represents the trajectory identifier.
+        datetime_column (str): The name of the column in the GeoDataFrame that
+            represents the datetime information.
+        temporal_columns (list, optional): A list of column names in the GeoDataFrame
+         that represent additional temporal properties. Defaults to None.
+        temporal_columns_static_fields (Dict[str, Dict], optional): A dictionary mapping
+            column names to static fields associated with the corresponding temporal
+            property. Defaults to None.
+        interpolation (str, optional): The interpolation method used for the temporal
+            geometry. Defaults to None.
         crs (optional): Coordinate reference system for the MF-JSON. Defaults to None.
         trs (optional): Temporal reference system for the MF-JSON. Defaults to None.
-        datetime_encoder (Callable[[any], str|int], optional): A function that encodes the datetime values in the
-            GeoDataFrame to a string ( IETF RFC 3339 ) or integer ( Timestamp, milliseconds ). Defaults to None.
+        datetime_encoder (Callable[[any], str|int], optional): A function that encodes
+            the datetime values in the GeoDataFrame to a string ( IETF RFC 3339 ) or
+            integer ( Timestamp, milliseconds ). Defaults to None.
     Returns:
         dict: The MF-JSON representation of the GeoDataFrame as a dictionary.
     """
@@ -102,9 +108,8 @@ def _raise_error_if_invalid_arguments(
 ):
     if not isinstance(gdf, GeoDataFrame):
         raise TypeError(
-            "Not a GeoDataFrame, but a {} was supplied. This function only works with GeoDataFrames.".format(
-                type(gdf)
-            )
+            "Not a GeoDataFrame, but a {} was supplied. This function only works with"
+            " GeoDataFrames.".format(type(gdf))
         )
     # Check if both datetime_column and trip_id_property are in the GeoDataFrame
     if datetime_column not in gdf.columns:

--- a/movingpandas/io.py
+++ b/movingpandas/io.py
@@ -38,12 +38,7 @@ def gdf_to_mf_json(
         dict: The MF-JSON representation of the GeoDataFrame as a dictionary.
     """
 
-    if not isinstance(gdf, GeoDataFrame):
-        raise ValueError(
-            "Not a GeoDataFrame, but a {} was supplied. This function only works with GeoDataFrames.".format(
-                type(gdf)
-            )
-        )
+    _raise_error_if_invalid_arguments(gdf, datetime_column, traj_id_property)
 
     if not temporal_properties:
         temporal_properties = []
@@ -100,6 +95,26 @@ def gdf_to_mf_json(
         rows.append(trajectory_data)
 
     return {"type": "FeatureCollection", "features": rows}
+
+
+def _raise_error_if_invalid_arguments(
+    gdf: GeoDataFrame, datetime_column: str, traj_id_property: str
+):
+    if not isinstance(gdf, GeoDataFrame):
+        raise TypeError(
+            "Not a GeoDataFrame, but a {} was supplied. This function only works with GeoDataFrames.".format(
+                type(gdf)
+            )
+        )
+    # Check if both datetime_column and trip_id_property are in the GeoDataFrame
+    if datetime_column not in gdf.columns:
+        raise ValueError(
+            f"The datetime_column {datetime_column} is not in the GeoDataFrame."
+        )
+    if traj_id_property not in gdf.columns:
+        raise ValueError(
+            f"The traj_id_property {traj_id_property} is not in the GeoDataFrame."
+        )
 
 
 def _retrieve_datetimes_from_row(datetime_column, datetime_encoder, row):

--- a/movingpandas/tests/test_io.py
+++ b/movingpandas/tests/test_io.py
@@ -1,8 +1,14 @@
 # -*- coding: utf-8 -*-
 import json
 import os
+
 import pytest
-from movingpandas.io import gdf_to_mf_json, read_mf_json, _create_objects_from_mf_json_dict
+
+from movingpandas.io import (
+    _create_objects_from_mf_json_dict,
+    gdf_to_mf_json,
+    read_mf_json,
+)
 
 
 class TestIO:
@@ -73,22 +79,34 @@ class TestIO:
         ).df
 
         loaded_gdf["t"] = loaded_gdf.index
-        loaded_gdf["id"] = '9569'
+        loaded_gdf["id"] = "9569"
 
         # Convert the GeoDataFrame to a Moving-Features JSON dictionary.
-        entity_mf_json = json.loads(json.dumps(gdf_to_mf_json(
-            loaded_gdf,
-            traj_id_property="id",
-            datetime_column="t",
-            datetime_encoder=lambda x: x.isoformat() + "Z",
-            temporal_properties=["wind", "pressure", "class"],
-            interpolation="Linear",
-            temporal_properties_static_fields={
-                "wind": {"form": "KNT", "interpolation": "Linear", "type": "Measure"},
-                "pressure": {"form": "A97", "interpolation": "Linear", "type": "Measure"},
-                "class": {"interpolation": "Linear", "type": "Measure"},
-            },
-        )["features"][0]))
+        entity_mf_json = json.loads(
+            json.dumps(
+                gdf_to_mf_json(
+                    loaded_gdf,
+                    traj_id_property="id",
+                    datetime_column="t",
+                    datetime_encoder=lambda x: x.isoformat() + "Z",
+                    temporal_properties=["wind", "pressure", "class"],
+                    interpolation="Linear",
+                    temporal_properties_static_fields={
+                        "wind": {
+                            "form": "KNT",
+                            "interpolation": "Linear",
+                            "type": "Measure",
+                        },
+                        "pressure": {
+                            "form": "A97",
+                            "interpolation": "Linear",
+                            "type": "Measure",
+                        },
+                        "class": {"interpolation": "Linear", "type": "Measure"},
+                    },
+                )["features"][0]
+            )
+        )
 
         # Load the expected result from the original Moving-Features JSON file.
         with open(os.path.join(self.test_dir, "movingfeatures.json"), "r") as f:

--- a/movingpandas/tests/test_io.py
+++ b/movingpandas/tests/test_io.py
@@ -2,6 +2,7 @@
 import json
 import os
 
+import pandas as pd
 import pytest
 
 from movingpandas.io import (
@@ -114,3 +115,25 @@ class TestIO:
 
         # Compare the expected and actual Moving-Features JSON dictionaries.
         assert entity_mf_json == expected_mf_json
+
+    def test_not_geodataframe_raises_error(self):
+        with pytest.raises(TypeError):
+            gdf_to_mf_json(
+                pd.DataFrame(),
+                traj_id_property="id",
+                datetime_column="t",
+            )
+
+    def test_missing_datetime_column_raises_error(self):
+        with pytest.raises(ValueError):
+            gdf_to_mf_json(
+                pd.DataFrame(),
+                traj_id_property="id",
+            )
+
+    def test_missing_traj_id_property_raises_error(self):
+        with pytest.raises(ValueError):
+            gdf_to_mf_json(
+                pd.DataFrame(),
+                datetime_column="t",
+            )

--- a/movingpandas/tests/test_io.py
+++ b/movingpandas/tests/test_io.py
@@ -87,12 +87,12 @@ class TestIO:
             json.dumps(
                 gdf_to_mf_json(
                     loaded_gdf,
-                    traj_id_property="id",
+                    traj_id_column="id",
                     datetime_column="t",
                     datetime_encoder=lambda x: x.isoformat() + "Z",
-                    temporal_properties=["wind", "pressure", "class"],
+                    temporal_columns=["wind", "pressure", "class"],
                     interpolation="Linear",
-                    temporal_properties_static_fields={
+                    temporal_columns_static_fields={
                         "wind": {
                             "form": "KNT",
                             "interpolation": "Linear",
@@ -120,19 +120,19 @@ class TestIO:
         with pytest.raises(TypeError):
             gdf_to_mf_json(
                 pd.DataFrame(),
-                traj_id_property="id",
+                traj_id_column="id",
                 datetime_column="t",
             )
 
     def test_missing_datetime_column_raises_error(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             gdf_to_mf_json(
                 pd.DataFrame(),
-                traj_id_property="id",
+                traj_id_column="id",
             )
 
     def test_missing_traj_id_property_raises_error(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             gdf_to_mf_json(
                 pd.DataFrame(),
                 datetime_column="t",


### PR DESCRIPTION
# Add gdf_to_mf_json Method

This pull request adds the gdf_to_mf_json method to the codebase. The gdf_to_mf_json method converts a GeoDataFrame to a dictionary compatible with the Moving Features JSON (MF-JSON) specification.

More precisely, the method transforms a **GeoDataFrame** made of Point geometries into a **Feature Collection** object. It can handle multiple trips with _different_ timestamps. The name of the columns that should be considered temporal properties can also be provided in order to include them as such in the resulting dictionary.

## Example
```
gdf = GeoDataFrame(...)

mf_json = gdf_to_mf_json(
    gdf=gdf,
    traj_id_property="trajectory_id",
    datetime_column="timestamp",
    temporal_properties=["speed", "acceleration"],
    temporal_properties_static_fields={
        "speed": {"uom": "m/s"},
        "acceleration": {"uom": "m/s^2"}
    },
)
```