### PR TITLE
Adding the timestamp column to the df returned by get_locations_at for a TrajectoryCollection

### DIFF
--- a/movingpandas/tests/test_trajectory_collection.py
+++ b/movingpandas/tests/test_trajectory_collection.py
@@ -2,6 +2,7 @@
 
 import pandas as pd
 import pytest
+from pandas import Timestamp
 from pandas.testing import assert_frame_equal
 from geopandas import GeoDataFrame
 from shapely.geometry import Point, Polygon, LineString
@@ -114,10 +115,18 @@ class TestTrajectoryCollection:
     def test_timestamp_column_present_in_start_locations(self):
         locs = self.collection.get_start_locations()
         assert "t" in locs.columns
+        assert locs["t"].tolist() == [
+            Timestamp("2018-01-01 12:00:00"),
+            Timestamp("2018-01-01 12:00:00"),
+        ]
 
     def test_timestamp_column_present_in_end_locations(self):
         locs = self.collection.get_end_locations()
         assert "t" in locs.columns
+        assert locs["t"].tolist() == [
+            Timestamp("2018-01-01 14:15:00"),
+            Timestamp("2018-01-02 13:15:00"),
+        ]
 
     def test_get_end_locations(self):
         locs = self.collection.get_end_locations()

--- a/movingpandas/tests/test_trajectory_collection.py
+++ b/movingpandas/tests/test_trajectory_collection.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 
+from copy import copy
+from datetime import datetime as datetime, timedelta as timedelta
+from math import sqrt
+
 import pandas as pd
 import pytest
+from fiona.crs import from_epsg
+from geopandas import GeoDataFrame
 from pandas import Timestamp
 from pandas.testing import assert_frame_equal
-from geopandas import GeoDataFrame
-from shapely.geometry import Point, Polygon, LineString
-from fiona.crs import from_epsg
-from datetime import datetime as datetime, timedelta as timedelta
-from copy import copy
-from math import sqrt
-from movingpandas.trajectory_collection import TrajectoryCollection
+from shapely.geometry import LineString, Point, Polygon
+
 from movingpandas.trajectory import TRAJ_ID_COL_NAME
-
+from movingpandas.trajectory_collection import TrajectoryCollection
 from . import requires_holoviews
-
 
 CRS_METRIC = from_epsg(31256)
 CRS_LATLON = from_epsg(4326)

--- a/movingpandas/tests/test_trajectory_collection.py
+++ b/movingpandas/tests/test_trajectory_collection.py
@@ -111,6 +111,14 @@ class TestTrajectoryCollection:
         assert locs.iloc[0].geometry != locs.iloc[1].geometry
         assert isinstance(locs, GeoDataFrame)
 
+    def test_timestamp_column_present_in_start_locations(self):
+        locs = self.collection.get_start_locations()
+        assert "t" in locs.columns
+
+    def test_timestamp_column_present_in_end_locations(self):
+        locs = self.collection.get_end_locations()
+        assert "t" in locs.columns
+
     def test_get_end_locations(self):
         locs = self.collection.get_end_locations()
         assert len(locs) == 2

--- a/movingpandas/trajectory_collection.py
+++ b/movingpandas/trajectory_collection.py
@@ -57,6 +57,7 @@ class TrajectoryCollection:
         """
         self.min_length = min_length
         self.min_duration = min_duration
+        self.t = t
         if type(data) == list:
             self.trajectories = [
                 traj for traj in data if traj.get_length() >= min_length
@@ -219,8 +220,8 @@ class TrajectoryCollection:
             Trajectory locations at timestamp t
         """
         result = []
+
         for traj in self:
-            x = None
             if t == "start":
                 x = traj.get_row_at(traj.get_start_time())
             elif t == "end":
@@ -231,7 +232,12 @@ class TrajectoryCollection:
                 x = traj.get_row_at(t)
             result.append(x.to_frame().T)
         if result:
-            df = concat(result, ignore_index=True)
+            df = concat(result)
+            # Move temporal index to column t
+            t = self.t or "t"
+            df.reset_index(inplace=True)
+            df.rename(columns={"index": t}, inplace=True)
+
             return GeoDataFrame(df)
         else:
             return GeoDataFrame()


### PR DESCRIPTION
This pull request adds the timestamp column to the dataframe returned by the **_get_locations_at_** method of the **_TrajectoryCollection_** class. This has for consequence that the get_start_locations and get_end_locations now also return the timestamp column.

Solving: #318 