### PR TITLE
Adding read_mf_dict function

### DIFF
--- a/movingpandas/io.py
+++ b/movingpandas/io.py
@@ -8,15 +8,16 @@ from movingpandas import Trajectory, TrajectoryCollection
 
 
 def gdf_to_mf_json(
-    gdf: GeoDataFrame,
-    traj_id_column: str,
-    datetime_column: str,
-    temporal_columns: list = None,
-    temporal_columns_static_fields: Dict[str, Dict] = None,
-    interpolation: str = None,
-    crs=None,
-    trs=None,
-    datetime_encoder: Callable = None,  # simplified typing hint due to https://github.com/movingpandas/movingpandas/issues/345  # noqa F401
+        gdf: GeoDataFrame,
+        traj_id_column: str,
+        datetime_column: str,
+        temporal_columns: list = None,
+        temporal_columns_static_fields: Dict[str, Dict] = None,
+        interpolation: str = None,
+        crs=None,
+        trs=None,
+        datetime_encoder: Callable = None,
+        # simplified typing hint due to https://github.com/movingpandas/movingpandas/issues/345  # noqa F401
 ) -> dict:
     """
     Converts a GeoDataFrame to a dictionary compatible with the Moving Features JSON
@@ -104,7 +105,7 @@ def gdf_to_mf_json(
 
 
 def _raise_error_if_invalid_arguments(
-    gdf: GeoDataFrame, datetime_column: str, traj_id_property: str
+        gdf: GeoDataFrame, datetime_column: str, traj_id_property: str
 ):
     if not isinstance(gdf, GeoDataFrame):
         raise TypeError(
@@ -130,7 +131,7 @@ def _retrieve_datetimes_from_row(datetime_column, datetime_encoder, row):
 
 
 def _encode_temporal_properties(
-    datetimes, row, temporal_properties, temporal_properties_static_fields
+        datetimes, row, temporal_properties, temporal_properties_static_fields
 ):
     temporal_properties_data = {
         "datetimes": datetimes,
@@ -168,6 +169,25 @@ def read_mf_json(json_file_path, traj_id_property=None, traj_id=0):
     """
     with open(json_file_path, "r") as f:
         data = json.loads(f.read())
+    return read_mf_dict(data, traj_id, traj_id_property)
+
+
+def read_mf_dict(data: dict, traj_id=0, traj_id_property=None):
+    """
+    Reads OGC Moving Features Encoding Extension JSON files from a dictionary.
+    MovingFeatures files are turned into Trajectory objects.
+    MovingFeatureCollection files are turned into TrajectoryCollection objects.
+    More info: http://www.opengis.net/doc/BP/mf-json/1.0
+
+    data : dict
+        JSON data as a dictionary
+    traj_id_property : str
+        Name of the MovingFeature JSON property to be used as trajectory ID
+    traj_id : any
+        Trajectory ID value to be used if no traj_id_property is supplied
+
+    Returns
+    """
     return _create_objects_from_mf_json_dict(data, traj_id_property, traj_id)
 
 
@@ -238,7 +258,7 @@ def _create_traj_from_movingfeature_json(data, traj_id_property, traj_id):
 
 def _create_trajcollection_from_movingfeaturecollection_json(data, traj_id_property):
     assert (
-        traj_id_property is not None
+            traj_id_property is not None
     ), "traj_id_property must be supplied when reading a collection of trajectories"
 
     trajectories = []

--- a/movingpandas/io.py
+++ b/movingpandas/io.py
@@ -8,16 +8,16 @@ from movingpandas import Trajectory, TrajectoryCollection
 
 
 def gdf_to_mf_json(
-        gdf: GeoDataFrame,
-        traj_id_column: str,
-        datetime_column: str,
-        temporal_columns: list = None,
-        temporal_columns_static_fields: Dict[str, Dict] = None,
-        interpolation: str = None,
-        crs=None,
-        trs=None,
-        datetime_encoder: Callable = None,
-        # simplified typing hint due to https://github.com/movingpandas/movingpandas/issues/345  # noqa F401
+    gdf: GeoDataFrame,
+    traj_id_column: str,
+    datetime_column: str,
+    temporal_columns: list = None,
+    temporal_columns_static_fields: Dict[str, Dict] = None,
+    interpolation: str = None,
+    crs=None,
+    trs=None,
+    datetime_encoder: Callable = None,
+    # simplified typing hint due to https://github.com/movingpandas/movingpandas/issues/345  # noqa F401
 ) -> dict:
     """
     Converts a GeoDataFrame to a dictionary compatible with the Moving Features JSON
@@ -105,7 +105,7 @@ def gdf_to_mf_json(
 
 
 def _raise_error_if_invalid_arguments(
-        gdf: GeoDataFrame, datetime_column: str, traj_id_property: str
+    gdf: GeoDataFrame, datetime_column: str, traj_id_property: str
 ):
     if not isinstance(gdf, GeoDataFrame):
         raise TypeError(
@@ -131,7 +131,7 @@ def _retrieve_datetimes_from_row(datetime_column, datetime_encoder, row):
 
 
 def _encode_temporal_properties(
-        datetimes, row, temporal_properties, temporal_properties_static_fields
+    datetimes, row, temporal_properties, temporal_properties_static_fields
 ):
     temporal_properties_data = {
         "datetimes": datetimes,
@@ -258,7 +258,7 @@ def _create_traj_from_movingfeature_json(data, traj_id_property, traj_id):
 
 def _create_trajcollection_from_movingfeaturecollection_json(data, traj_id_property):
     assert (
-            traj_id_property is not None
+        traj_id_property is not None
     ), "traj_id_property must be supplied when reading a collection of trajectories"
 
     trajectories = []

--- a/movingpandas/point_clusterer.py
+++ b/movingpandas/point_clusterer.py
@@ -81,7 +81,7 @@ class _Grid:
                     g.add_point(pt)
                     g.recompute_centroid()
                 else:
-                    print(f"Error: no group in cell {i},{j}")
+                    print(f"Error: no group in cell {i}, {j}")
                     print(pt)
 
     def get_group(self, centroid):

--- a/movingpandas/tests/test_io.py
+++ b/movingpandas/tests/test_io.py
@@ -8,7 +8,8 @@ import pytest
 from movingpandas.io import (
     _create_objects_from_mf_json_dict,
     gdf_to_mf_json,
-    read_mf_json, read_mf_dict,
+    read_mf_json,
+    read_mf_dict,
 )
 
 
@@ -28,18 +29,28 @@ class TestIO:
         assert actual == expected
 
     def test_read_mf_dict(self):
-        data = {
-            "type": "Feature",
-            "properties": {"id": 5},
-            "temporalGeometry": {
-                "type": "MovingPoint",
-                "datetimes": ["2008-02-02T15:02:18Z", "2008-02-02T18:32:28Z"],
-                "coordinates": [[116.52299, 40.07757], [116.52302, 39.92129]],
-            },
+        collection = {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "properties": {"id": 5},
+                    "temporalGeometry": {
+                        "type": "MovingPoint",
+                        "datetimes": ["2008-02-02T15:02:18Z", "2008-02-02T18:32:28Z"],
+                        "coordinates": [[116.52299, 40.07757], [116.52302, 39.92129]],
+                    },
+                }
+            ],
         }
-        traj = read_mf_dict(data, "id")
+        trajs_collection = read_mf_dict(collection, traj_id_property="id")
+
+        assert len(trajs_collection) == 1
+        assert trajs_collection.get_trajectory(5).id == 5
+
+        traj = read_mf_dict(collection["features"][0], traj_id_property="id")
+
         assert traj.id == 5
-        assert traj.size() == 2
 
     def test_mf_collection_file(self):
         trajs_collection = read_mf_json(

--- a/movingpandas/tests/test_io.py
+++ b/movingpandas/tests/test_io.py
@@ -8,7 +8,7 @@ import pytest
 from movingpandas.io import (
     _create_objects_from_mf_json_dict,
     gdf_to_mf_json,
-    read_mf_json,
+    read_mf_json, read_mf_dict,
 )
 
 
@@ -26,6 +26,20 @@ class TestIO:
         actual = list(traj.df["pressure"])
         expected = [1004.0, 1004.0, 1004.0, 1004.0, 1000.0]
         assert actual == expected
+
+    def test_read_mf_dict(self):
+        data = {
+            "type": "Feature",
+            "properties": {"id": 5},
+            "temporalGeometry": {
+                "type": "MovingPoint",
+                "datetimes": ["2008-02-02T15:02:18Z", "2008-02-02T18:32:28Z"],
+                "coordinates": [[116.52299, 40.07757], [116.52302, 39.92129]],
+            },
+        }
+        traj = read_mf_dict(data, "id")
+        assert traj.id == 5
+        assert traj.size() == 2
 
     def test_mf_collection_file(self):
         trajs_collection = read_mf_json(

--- a/movingpandas/tools/_show_versions.py
+++ b/movingpandas/tools/_show_versions.py
@@ -137,12 +137,12 @@ def show_versions():
     print("\nSYSTEM INFO")
     print("-----------")
     for k, stat in sys_info.items():
-        print(f"{k:<{maxlen}}: {stat}")
+        print(f"{k: <{maxlen}}: {stat}")
     print("\nGEOS, GDAL, PROJ INFO")
     print("---------------------")
     for k, stat in proj_info.items():
-        print(f"{k:<{maxlen}}: {stat}")
+        print(f"{k: <{maxlen}}: {stat}")
     print("\nPYTHON DEPENDENCIES")
     print("-------------------")
     for k, stat in deps_info.items():
-        print(f"{k:<{maxlen}}: {stat}")
+        print(f"{k: <{maxlen}}: {stat}")

--- a/movingpandas/trajectory.py
+++ b/movingpandas/trajectory.py
@@ -183,7 +183,7 @@ class Trajectory:
             return "Invalid trajectory!"
         return (
             f"Trajectory {self.id} ({self.get_start_time()} to {self.get_end_time()}) "
-            f"| Size: {self.size()} | Length:{self.get_length(): .1f}m\n"
+            f"| Size: {self.size()} | Length: {round(self.get_length(), 1)}m\n"
             f"Bounds: {self.get_bbox()}\n{line.wkt[:100]}"
         )
 

--- a/movingpandas/trajectory.py
+++ b/movingpandas/trajectory.py
@@ -183,7 +183,7 @@ class Trajectory:
             return "Invalid trajectory!"
         return (
             f"Trajectory {self.id} ({self.get_start_time()} to {self.get_end_time()}) "
-            f"| Size: {self.size()} | Length: {self.get_length():.1f}m\n"
+            f"| Size: {self.size()} | Length: {self.get_length(): .1f}m\n"
             f"Bounds: {self.get_bbox()}\n{line.wkt[:100]}"
         )
 

--- a/movingpandas/trajectory.py
+++ b/movingpandas/trajectory.py
@@ -183,7 +183,7 @@ class Trajectory:
             return "Invalid trajectory!"
         return (
             f"Trajectory {self.id} ({self.get_start_time()} to {self.get_end_time()}) "
-            f"| Size: {self.size()} | Length: {self.get_length(): .1f}m\n"
+            f"| Size: {self.size()} | Length:{self.get_length(): .1f}m\n"
             f"Bounds: {self.get_bbox()}\n{line.wkt[:100]}"
         )
 


### PR DESCRIPTION
The only way of parsing an MF-JSON file is through the read_mf_file function. This forces the user working with in-memory data to write the data to a temporary file.

The proposed function allows one to parse the data from a dictionary directly. 

The read_mf_file is now a wrapper around it, so there is no duplication of logic.

(It would be really nice if it could make it to the package before 13th of November 😃 (Sigspatial))