### PR TITLE
Fix typo in TrajectoryCollection.add_timedelta() adding distance instead

### DIFF
--- a/movingpandas/trajectory_collection.py
+++ b/movingpandas/trajectory_collection.py
@@ -752,9 +752,9 @@ class TrajectoryCollection:
             Number of threads to use for computation (default: 1)
         """
         if n_threads <= 1:
-            self._add_distance(self.trajectories, name, UNITS(), overwrite)
+            self._add_timedelta(self.trajectories, name, UNITS(), overwrite)
         else:
-            self._multithread(self._add_distance, n_threads, name, UNITS(), overwrite)
+            self._multithread(self._add_timedelta, n_threads, name, UNITS(), overwrite)
         return self
 
     def _add_timedelta(self, trajs, name, units, overwrite):


### PR DESCRIPTION
Fixing regression in 89f2acf causing `add_timedelta` to add distance instead.

I have *not* run the test suite locally, and I also haven't added any new tests to prevent this bug in future.