### PR TITLE
Update failing linting stage

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-      - uses: pre-commit/action@v2.0.3
+      - uses: pre-commit/action@v3.0.1
 
   Test:
     #needs: Linting

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,4 +10,4 @@ repos:
     hooks:
       - id: flake8
         language_version: python3
-        language: python_venv
+        language: python


### PR DESCRIPTION
Linting started failing: 

```
Run pre-commit/action@v2.0.3
install pre-commit
/opt/hostedtoolcache/Python/3.12.[7](https://github.com/movingpandas/movingpandas/actions/runs/11265688955/job/31327930931#step:4:8)/x64/bin/pre-commit run --show-diff-on-failure --color=always --all-files
An error has occurred: InvalidConfigError: 
==> File .pre-commit-config.yaml
==> At Config()
==> At key: repos
==> At Repository(repo='https://github.com/pycqa/flake8')
==> At key: hooks
==> At Hook(id='flake8')
==> At key: language
=====> Expected one of conda, coursier, dart, docker, docker_image, dotnet, fail, golang, haskell, lua, node, perl, pygrep, python, r, ruby, rust, script, swift, system but got: 'python_venv'
Check the log at /home/runner/.cache/pre-commit/pre-commit.log
Error: The process '/opt/hostedtoolcache/Python/3.12.7/x64/bin/pre-commit' failed with exit code 1
```

There are newer versions of this action: https://github.com/pre-commit/action/releases