### PR TITLE
Switch to micromamba

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -52,24 +52,22 @@ jobs:
             os: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - name: Setup Conda
-        uses: conda-incubator/setup-miniconda@v2
+      - name: Install Conda environment with Micromamba
+        uses: mamba-org/setup-micromamba@v2
         with:
           environment-file: ${{ matrix.env }}
-          miniforge-version: latest
-          miniforge-variant: Mambaforge
-          use-mamba: true
 
       - name: Check and Log Environment
         run: |
           python -V
           python -c "import movingpandas; movingpandas.show_versions();"
-          conda info
-
+          micromamba info
+          micromamba list
+          
       - name: Test
         run: |
           pytest -v -r s --color=yes --cov=movingpandas --cov-append --cov-report term-missing --cov-report xml movingpandas/
 
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v5


### PR DESCRIPTION
Should fix the testing errors due to deprecated mambaforge https://github.com/movingpandas/movingpandas/actions/runs/12540405549/job/34967653677#step:3:122

```
Extracting mamba-1.5.11-py312h9460a1c_0.conda
  Warning: Future Miniforge releases will NOT build Mambaforge installers. We advise you switch to Miniforge at your earliest convenience. More details at [https://conda-forge.org/news/2024/07/29/sunsetting-mambaforge/.](https://conda-forge.org/news/2024/07/29/sunsetting-mambaforge/)
  Warning: ERROR: executing pre_install.sh failed
  
  ERROR: executing pre_install.sh failed
Error: The process '/usr/bin/bash' failed with exit code 1
```

Based on https://github.com/geopandas/geopandas/blob/37cf1ab2b452ff059e4dd57a298a6fa07b1311ed/.github/workflows/tests.yaml