### PR TITLE
Remove debugging print statement

### DIFF
--- a/movingpandas/trajectory_splitter.py
+++ b/movingpandas/trajectory_splitter.py
@@ -99,7 +99,7 @@ class TemporalSplitter(TrajectorySplitter):
                 f"split size of {mode}. Consider running the ObservationGapSplitter to "
                 f"further clean the results."
             )
-        print(dfs)
+
         for i, df in enumerate(dfs):
             if i < len(dfs) - 1:
                 next_index = dfs[i + 1].iloc[0].name


### PR DESCRIPTION
Minor issue:
- Accidentally a print statement was added, now removed.

I could add a flake8 or similar check in the github workflow to prevent this if I continue the cpa in the next weeks. 