### PR TITLE
Add multiprocess support to `TrajectorySplitters`

### DIFF
--- a/movingpandas/trajectory_splitter.py
+++ b/movingpandas/trajectory_splitter.py
@@ -64,7 +64,7 @@ class TrajectorySplitter:
         else:
             raise TypeError
 
-    def _split_traj_collection(self, trajs, **kwargs) -> TrajectoryCollection:
+    def _split_traj_collection(self, trajs, **kwargs):
         trips = []
 
         for traj in trajs:


### PR DESCRIPTION
Closes #461 

- There are some minor internal API changes to facilitate this but nothing on the user-facing end.
- The tests are taken from the single-processing version and expanded to use multiprocessing. I hope that is okay.
- Also, renamed a test method inside `test_trajectory_splitter.py` to follow proper naming convention.

Let me know what you think about it, @anitagraser 