### PR TITLE
include x, y in copy

### DIFF
--- a/movingpandas/tests/test_trajectory.py
+++ b/movingpandas/tests/test_trajectory.py
@@ -1177,6 +1177,5 @@ class TestTrajectoryNonGeo:
         traj = traj_0.copy()
         assert traj.x == traj_0.x
         assert traj.y == traj_0.y
-        traj.populate_geometry_column()
         traj.add_speed()
         traj.add_direction()

--- a/movingpandas/tests/test_trajectory.py
+++ b/movingpandas/tests/test_trajectory.py
@@ -1172,8 +1172,11 @@ class TestTrajectoryNonGeo:
         assert self.traj_xyt.get_start_location() == Point(0, 0)
         assert self.traj_abc.get_start_location() == Point(0, 0)
 
-    def test_traj_copy_x_y(self):
+    def test_traj_copy_custom_col(self):
         traj_0 = self.traj_abc
         traj = traj_0.copy()
         assert traj.x == traj_0.x
         assert traj.y == traj_0.y
+        traj.populate_geometry_column()
+        traj.add_speed()
+        traj.add_direction()

--- a/movingpandas/tests/test_trajectory.py
+++ b/movingpandas/tests/test_trajectory.py
@@ -1171,3 +1171,9 @@ class TestTrajectoryNonGeo:
     def test_start_location_nongeo(self):
         assert self.traj_xyt.get_start_location() == Point(0, 0)
         assert self.traj_abc.get_start_location() == Point(0, 0)
+
+    def test_traj_copy_x_y(self):
+        traj_0 = self.traj_abc
+        traj = traj_0.copy()
+        assert traj.x == traj_0.x
+        assert traj.y == traj_0.y

--- a/movingpandas/trajectory.py
+++ b/movingpandas/trajectory.py
@@ -250,6 +250,8 @@ class Trajectory:
             self.id,
             parent=self.parent,
             traj_id_col=self.traj_id_col_name,
+            x=self.x,
+            y=self.y,
         )
         return copied
 


### PR DESCRIPTION
otherwise trying to work with a copy can result in:

```
traj.copy().populate_geometry_column()
...
File [/srv/conda/envs/notebook/lib/python3.12/site-packages/movingpandas/trajectory.py:196](https://gfts.minrk.net/srv/conda/envs/notebook/lib/python3.12/site-packages/movingpandas/trajectory.py#line=195), in Trajectory.requires_geometry.<locals>.wrapper(self, *args, **kwargs)
    193 @wraps(func)
    194 def wrapper(self, *args, **kwargs):
    195     if self.df.geometry.isnull().all():
--> 196         self.populate_geometry_column()
    197     return func(self, *args, **kwargs)

File [/srv/conda/envs/notebook/lib/python3.12/site-packages/movingpandas/trajectory.py:203](https://gfts.minrk.net/srv/conda/envs/notebook/lib/python3.12/site-packages/movingpandas/trajectory.py#line=202), in Trajectory.populate_geometry_column(self)
    201 def populate_geometry_column(self):
    202     if self.x is None or self.y is None:
--> 203         raise ValueError("x and y coordinate column names must be set.")
    204     self.df.geometry = points_from_xy(self.df[self.x], self.df[self.y])
    205     self.df.drop(columns=[self.x, self.y], inplace=True)

ValueError: x and y coordinate column names must be set.
```

Missed in #458, I think.