### PR TITLE
Clarify what the trajectory similarity measures return

### DIFF
--- a/movingpandas/trajectory.py
+++ b/movingpandas/trajectory.py
@@ -1783,16 +1783,8 @@ class Trajectory:
         ``radius``. FastDTW never underestimates the exact distance, and a
         larger ``radius`` generally gets closer to the exact distance at the
         cost of speed. The approximation is not guaranteed to improve at
-        every step, though. FastDTW repeatedly halves both sequences, aligns
-        the shortest pair, and then searches only the cells within
-        ``radius`` of that alignment as it projects it back up to full
-        resolution. Since ``radius`` also decides how far the halving goes,
-        changing it changes which coarse alignment gets refined, and the
-        cells searched at one ``radius`` are not necessarily a subset of
-        those searched at a larger one. An individual increase can therefore
-        move the estimate further from the exact distance. Euclidean point
-        distances are used throughout, in both the exact and the approximate
-        computation.
+        every step, though. Euclidean point distances are used throughout, in
+        both the exact and the approximate computation.
 
         Distances are computed using Euclidean geometry, so a
         ``UserWarning`` is raised for trajectories in a geographic (lat/lon)

--- a/movingpandas/trajectory.py
+++ b/movingpandas/trajectory.py
@@ -1783,10 +1783,16 @@ class Trajectory:
         ``radius``. FastDTW never underestimates the exact distance, and a
         larger ``radius`` generally gets closer to the exact distance at the
         cost of speed. The approximation is not guaranteed to improve at
-        every step, though: because FastDTW refines a path found on
-        coarsened sequences, an individual increase of ``radius`` can move
-        the estimate further away. Euclidean point distances are used
-        throughout, in both the exact and the approximate computation.
+        every step, though. FastDTW repeatedly halves both sequences, aligns
+        the shortest pair, and then searches only the cells within
+        ``radius`` of that alignment as it projects it back up to full
+        resolution. Since ``radius`` also decides how far the halving goes,
+        changing it changes which coarse alignment gets refined, and the
+        cells searched at one ``radius`` are not necessarily a subset of
+        those searched at a larger one. An individual increase can therefore
+        move the estimate further from the exact distance. Euclidean point
+        distances are used throughout, in both the exact and the approximate
+        computation.
 
         Distances are computed using Euclidean geometry, so a
         ``UserWarning`` is raised for trajectories in a geographic (lat/lon)

--- a/movingpandas/trajectory.py
+++ b/movingpandas/trajectory.py
@@ -1779,10 +1779,14 @@ class Trajectory:
         time (and O(n+m) memory, the dynamic program is evaluated in
         vectorized anti-diagonal slices). For long trajectories, pass
         ``radius`` to use the FastDTW approximation by Salvador & Chan
-        (2007), which runs in O(n) time and memory. FastDTW never
-        underestimates the exact distance, and a larger ``radius`` gets
-        closer to it at the cost of speed. Euclidean point distances are
-        used throughout, in both the exact and the approximate computation.
+        (2007), which runs in linear time and memory for a given
+        ``radius``. FastDTW never underestimates the exact distance, and a
+        larger ``radius`` generally gets closer to the exact distance at the
+        cost of speed. The approximation is not guaranteed to improve at
+        every step, though: because FastDTW refines a path found on
+        coarsened sequences, an individual increase of ``radius`` can move
+        the estimate further away. Euclidean point distances are used
+        throughout, in both the exact and the approximate computation.
 
         Distances are computed using Euclidean geometry, so a
         ``UserWarning`` is raised for trajectories in a geographic (lat/lon)
@@ -1899,10 +1903,15 @@ class Trajectory:
         sequences such that each matched pair is within ``epsilon`` and, if
         ``delta`` is given, no more than ``delta`` positions apart in the
         sequences. The similarity is that count divided by the length of the
-        shorter sequence, and the returned distance is ``1 - similarity`` (0
-        means the trajectories match everywhere, 1 means no points match).
-        Because unmatched points are simply skipped, LCSS is robust to noise
-        and outliers, unlike DTW and Fréchet distance.
+        shorter sequence, and the returned distance is ``1 - similarity``. So
+        0 means every point of the shorter trajectory found a match, i.e. it
+        is essentially a (noisy) subsequence of the other, and 1 means no
+        points match within ``epsilon``. Points of the longer trajectory that
+        are left over do not count against the result. Because unmatched
+        points are simply skipped, LCSS is more robust to noise and
+        outliers than DTW and Fréchet distance, which must account for every
+        point. Values are only comparable between trajectory pairs when they
+        were computed with the same ``epsilon`` and ``delta``.
 
         The similarity is computed with a vectorized dynamic program that
         keeps only two anti-diagonals of the DP matrix in memory. Without
@@ -1958,7 +1967,11 @@ class Trajectory:
         https://shapely.readthedocs.io/en/stable/reference/shapely.frechet_distance.html).
         The Fréchet distance is a measure of the similarity between curves
         that takes into account the location and ordering of the points along
-        the curves.
+        the curves. Shapely computes the *discrete* Fréchet distance, which
+        only considers the recorded points and not the line interpolated
+        between them. The result therefore depends on how densely each
+        trajectory is sampled, and a coarsely sampled trajectory can score
+        much higher than the shape of the curves alone would suggest.
 
         The distance is computed using Euclidean geometry, so a ``UserWarning``
         is raised for trajectories in a geographic (lat/lon) CRS. Project to a


### PR DESCRIPTION
Follow-up to #500, #502 and #503 now that they're out in 0.23.0. Docs only, no code changes.

Three things in the new docstrings are incomplete or actively misleading:

**`frechet_distance`** doesn't say the result is the *discrete* Fréchet distance. Shapely/GEOS pairs only the recorded vertices, so the value depends on how densely each trajectory is sampled, and the effect can be large. A straight line and a shallow detour that sit about 1 unit apart everywhere:

```
straight (2 pts) vs detour (3 pts): 50.010
straight (3 pts) vs detour (3 pts):  1.000
```

Same two curves. Only the sampling of the straight line changed.

**`dtw_distance`** says a larger `radius` "gets closer to" the exact distance. That isn't guaranteed. FastDTW refines a path found on coarsened sequences, so an individual increase in `radius` can move the estimate further away:

```
radius 1 -> 2: 877.784703 -> 880.388352   (exact 874.837355)
radius 2 -> 3: 887.642031 -> 887.832457   (exact 887.340732)
```

The same paragraph also said the approximation runs in "O(n) time and memory", which drops the `radius` factor. It now reads "linear time and memory for a given `radius`".

**`lcss_distance`** says 0 means "the trajectories match everywhere". It doesn't. The match count is divided by the length of the *shorter* sequence, so leftover points on the longer trajectory don't count against the result. A 3-point trajectory scores 0.0 against a 6-point trajectory that merely starts with those same 3 points. I also noted that values are only comparable across trajectory pairs computed with the same `epsilon` and `delta`, since the measure is normalized but the thresholds aren't.

black and flake8 clean, `test_trajectory.py` passes (178 passed, 7 skipped).
