### PR TITLE
Add cross-validated tests for MobilityMetricsCalculator

### DIFF
--- a/movingpandas/tests/test_home_detection.py
+++ b/movingpandas/tests/test_home_detection.py
@@ -1,0 +1,706 @@
+"""Compares movingpandas' `MobilityMetricsCalculator.home_location()`
+against HoWDe's `HoWDe_labelling()` on the same stop-sequence data.
+
+- `home_location()` (movingpandas): most-visited location during a fixed
+  22:00-07:00 nighttime window, no data-quality filter, sets one single
+  home for a user's entire history.
+- `HoWDe_labelling()` (HoWDe, https://github.com/LLucchini/HoWDe): a
+  sliding-window heuristic with explicit data-quality gates (`C_days_H`,
+  `f_hours_H`) that can re-evaluate over time and can legitimately return
+  no home when data is too sparse or ambiguous.
+
+Two independent sections, each usable on its own:
+1. Synthetic scenarios ("regular", "gappy", "ambiguous_nights") -- always
+   run, no extra setup.
+2. An optional, user-supplied dataset with ground truth at USER-WEEK
+   granularity -- reports accuracy scored per user-week (movingpandas'
+   single whole-history guess is broadcast across every week it has data
+   for, since it doesn't re-evaluate over time).
+
+Self-contained: only third-party packages (movingpandas, pandas, geopandas,
+shapely, geopy, pytest, and optionally pyspark + HoWDe) are imported --
+nothing from elsewhere in this repository, so this file can be copied and
+run on its own.
+
+--------------------------------------------------------------------------
+SETUP
+--------------------------------------------------------------------------
+    pip install movingpandas pandas geopandas shapely geopy pytest
+    pip install pyspark HoWDe   # optional, needed for section 2; needs a working Java
+
+--------------------------------------------------------------------------
+RUN -- synthetic scenarios (always available)
+--------------------------------------------------------------------------
+    pytest test_home_detection.py -v -s
+    python test_home_detection.py                  # prints a full report
+
+--------------------------------------------------------------------------
+RUN -- against week-level ground truth (per-user-week accuracy)
+--------------------------------------------------------------------------
+Point WEEKLY_STOPS_PATH at a stops directory (useruuid, loc, start, end) and
+WEEKLY_TRUELABELS_PATH at a directory with columns useruuid, s_yy, s_woy,
+loc, true_location_type:
+    WEEKLY_STOPS_PATH=/path/to/stops WEEKLY_TRUELABELS_PATH=/path/to/truelabels_uwy \\
+        pytest test_home_detection.py -v -s -k weekly
+    WEEKLY_STOPS_PATH=... WEEKLY_TRUELABELS_PATH=... python test_home_detection.py
+"""
+
+import glob
+import math
+import os
+import random
+
+import geopandas as gpd
+import movingpandas as mpd
+import pandas as pd
+import pytest
+from geopy.distance import distance as geopy_distance
+from shapely.geometry import Point
+
+try:
+    from pyspark.sql import SparkSession
+    from pyspark.sql import functions as F
+
+    from howde import HoWDe_labelling
+
+    HAVE_HOWDE = True
+except ImportError:
+    HAVE_HOWDE = False
+
+# No default for the real-data path -- it's opt-in via env var and
+# skips/errors cleanly when unset, so this file works out of the box on
+# synthetic data alone.
+WEEKLY_STOPS_PATH = os.environ.get("WEEKLY_STOPS_PATH")
+WEEKLY_TRUELABELS_PATH = os.environ.get("WEEKLY_TRUELABELS_PATH")
+WEEKLY_MAX_USERS = int(os.environ.get("WEEKLY_MAX_USERS", 0))  # 0 = all users
+
+pd.set_option("display.width", 200)
+pd.set_option("display.max_columns", 20)
+
+
+# ===========================================================================
+# Shared utilities (inlined so this file has no dependency on anything else
+# in this repository)
+# ===========================================================================
+def dedupe_stops(
+    df, user_col="useruuid", time_col="start", duration_col=None, verbose=True
+):
+    """Remove (user_col, time_col) collisions from a stops DataFrame.
+
+    Real stop-sequence exports can contain exact duplicate rows, and
+    occasionally two genuinely different rows that share a (user,
+    timestamp) pair -- neither should reach movingpandas/HoWDe silently.
+    Two passes:
+      1. Exact full-row duplicates are dropped outright.
+      2. Remaining (user_col, time_col) collisions are resolved by keeping
+         the longest-duration row (using `duration_col`/`end`), logged with
+         counts; falls back to first-row-wins if no duration signal.
+    """
+    n0 = len(df)
+    df = df.drop_duplicates()
+    n1 = len(df)
+    exact_dupes_dropped = n0 - n1
+    if verbose and exact_dupes_dropped:
+        print(
+            f"[dedupe_stops] dropped {exact_dupes_dropped} exact full-row duplicates "
+            f"({exact_dupes_dropped / n0:.1%} of {n0} input rows)"
+        )
+
+    collision_mask = df.duplicated(subset=[user_col, time_col], keep=False)
+    if collision_mask.sum() == 0:
+        return df
+
+    collisions = df[collision_mask]
+    n_groups = collisions.groupby([user_col, time_col]).ngroups
+
+    if duration_col is None and "end" in df.columns:
+        duration_col = "end"
+    if duration_col is not None and duration_col in df.columns:
+        df = df.assign(_dur=(df[duration_col] - df[time_col]))
+        df = df.sort_values("_dur", ascending=False)
+        rule = (
+            f"kept longest-duration row per group (using {duration_col} - {time_col})"
+        )
+    else:
+        rule = (
+            "kept first row per group (no duration column available to break ties on)"
+        )
+
+    deduped = df[~df.duplicated(subset=[user_col, time_col], keep="first")]
+    if "_dur" in deduped.columns:
+        deduped = deduped.drop(columns="_dur")
+
+    n_dropped = len(df) - len(deduped)
+    if verbose:
+        print(
+            f"[dedupe_stops] found {n_groups} residual ({user_col}, {time_col}) collision "
+            f"groups ({collision_mask.sum()} rows involved, not exact duplicates) -- {rule}. "
+            f"Dropped {n_dropped} rows."
+        )
+    return deduped.sort_values([user_col, time_col]).reset_index(drop=True)
+
+
+# EPR/Levy-flight fabricated coordinates: HoWDe-shaped stop data has only
+# categorical location ids, no lat/lon, but home_location() needs geometry.
+# Parameters from Gonzalez, Hidalgo & Barabasi (2008) "Understanding
+# individual human mobility patterns", Nature 453, 779-782; placement
+# scheme from Song, Koren, Wang & Barabasi (2010) "Modelling the scaling
+# properties of human mobility", Nature Physics 6, 818-823 -- the same EPR
+# model already cited in movingpandas' own waiting_times()/
+# k_radius_of_gyration() docstrings. This does not make the resulting
+# distances real, only statistically representative of real human mobility
+# distance distributions -- good enough for exercising both detectors on
+# realistic-scale data, not for reading any single distance as a real
+# measurement.
+_JUMP_BETA = 1.75
+_JUMP_R0_KM = 1.5
+_JUMP_KAPPA_KM = 400.0
+
+
+def _sample_jump_length_km(
+    rng, beta=_JUMP_BETA, r0_km=_JUMP_R0_KM, kappa_km=_JUMP_KAPPA_KM, max_tries=1000
+):
+    for _ in range(max_tries):
+        u = rng.random()
+        dr = r0_km * ((1 - u) ** (-1 / (beta - 1)) - 1)
+        if rng.random() <= math.exp(-dr / kappa_km):
+            return dr
+    return kappa_km
+
+
+def assign_epr_coordinates(df, origin=(48.2082, 16.3738), seed=42):
+    """Assign a (lat, lon) to every (useruuid, loc) pair in df via an
+    EPR-style exploration walk, processed in time order per user. Returns
+    df with two new columns, lat_synth / lon_synth.
+    """
+    rng = random.Random(seed)
+    df_sorted = df.sort_values(["useruuid", "start"])
+
+    assigned = {}
+    current_pos = {}
+    lat_out, lon_out = [], []
+    for row in df_sorted.itertuples(index=False):
+        key = (row.useruuid, row.loc)
+        if key in assigned:
+            lat, lon = assigned[key]
+        elif row.useruuid not in current_pos:
+            lat, lon = origin  # first stop ever seen for this user -> shared anchor
+            assigned[key] = (lat, lon)
+        else:
+            dr_km = _sample_jump_length_km(rng)
+            bearing_deg = rng.uniform(0, 360)
+            dest = geopy_distance(kilometers=dr_km).destination(
+                current_pos[row.useruuid], bearing=bearing_deg
+            )
+            lat, lon = dest.latitude, dest.longitude
+            assigned[key] = (lat, lon)
+
+        current_pos[row.useruuid] = (lat, lon)
+        lat_out.append(lat)
+        lon_out.append(lon)
+
+    df_sorted = df_sorted.copy()
+    df_sorted["lat_synth"] = lat_out
+    df_sorted["lon_synth"] = lon_out
+    return df_sorted
+
+
+# ===========================================================================
+# Spark session (module-scoped fixture for pytest; a plain function for
+# __main__, same helper either way)
+# ===========================================================================
+def _make_spark():
+    spark = (
+        SparkSession.builder.master("local[*]")
+        .appName("test_home_detection")
+        .getOrCreate()
+    )
+    spark.conf.set("spark.sql.shuffle.partitions", "4")
+    return spark
+
+
+@pytest.fixture(scope="module")
+def spark():
+    if not HAVE_HOWDE:
+        pytest.skip("pip install pyspark HoWDe")
+    s = _make_spark()
+    yield s
+    s.stop()
+
+
+# ===========================================================================
+# Synthetic scenarios
+# ===========================================================================
+ORIGIN_DAY = pd.Timestamp("2024-01-01")  # a Monday
+N_DAYS = 35  # > HoWDe's default range_window_home=28
+
+
+def _overnight_stop(uid, loc, day_idx, country="US"):
+    """One continuous stay from day 22:00 to (day+1) 07:00 -- HoWDe splits
+    multi-day stops into daily segments itself; for movingpandas we only
+    ever emit ONE Point per stop row (at its start time), so a single
+    overnight stay contributes exactly one nighttime-window count, not one
+    per raw ping.
+    """
+    start = ORIGIN_DAY + pd.Timedelta(days=day_idx, hours=22)
+    end = ORIGIN_DAY + pd.Timedelta(days=day_idx + 1, hours=7)
+    return (uid, loc, int(start.timestamp()), int(end.timestamp()), country)
+
+
+def _daytime_stop(uid, loc, day_idx, start_hour, end_hour, country="US"):
+    start = ORIGIN_DAY + pd.Timedelta(days=day_idx, hours=start_hour)
+    end = ORIGIN_DAY + pd.Timedelta(days=day_idx, hours=end_hour)
+    return (uid, loc, int(start.timestamp()), int(end.timestamp()), country)
+
+
+def build_synthetic_stops(scenario, uid="synthetic_user", seed=0):
+    """Returns (stops_df, true_home_loc_or_None).
+
+    `true_home_loc_or_None` is None for "ambiguous_nights", where there is
+    deliberately no single correct answer -- that scenario is descriptive
+    (report what each detector picks), not a pass/fail check.
+    """
+    rows = []
+
+    if scenario == "regular":
+        for d in range(N_DAYS):
+            rows.append(_overnight_stop(uid, "home", d))
+            if (ORIGIN_DAY + pd.Timedelta(days=d)).dayofweek < 5:  # weekday
+                rows.append(_daytime_stop(uid, "work", d, 9, 17))
+            if d % 6 == 0:
+                rows.append(_daytime_stop(uid, "cafe", d, 12, 13))
+        true_home = "home"
+
+    elif scenario == "gappy":
+        import random
+
+        rng = random.Random(seed)
+        for d in range(N_DAYS):
+            if rng.random() < 0.30:  # only ~30% of nights have data
+                rows.append(_overnight_stop(uid, "home", d))
+            if (
+                ORIGIN_DAY + pd.Timedelta(days=d)
+            ).dayofweek < 5 and rng.random() < 0.30:
+                rows.append(_daytime_stop(uid, "work", d, 9, 17))
+        true_home = "home"
+
+    elif scenario == "ambiguous_nights":
+        import random
+
+        rng = random.Random(seed)
+        for d in range(N_DAYS):
+            loc = "home_a" if rng.random() < 0.5 else "home_b"
+            rows.append(_overnight_stop(uid, loc, d))
+            if (ORIGIN_DAY + pd.Timedelta(days=d)).dayofweek < 5:
+                rows.append(_daytime_stop(uid, "work", d, 9, 17))
+        true_home = None
+
+    else:
+        raise ValueError(f"unknown scenario {scenario!r}")
+
+    df = pd.DataFrame(rows, columns=["useruuid", "loc", "start", "end", "country"])
+    return df.sort_values(["useruuid", "start"]).reset_index(drop=True), true_home
+
+
+# ===========================================================================
+# Coordinate fabrication + reverse lookup
+# ===========================================================================
+def build_coord_lookup(stops_df, seed=42):
+    """(useruuid, loc) -> (lat, lon), plus the reverse mapping, via the
+    EPR/Levy-flight fabrication above -- home_location() needs geometry;
+    HoWDe-shaped stop data has none.
+    """
+    coords_df = assign_epr_coordinates(stops_df, seed=seed)
+    per_loc = coords_df[["useruuid", "loc", "lat_synth", "lon_synth"]].drop_duplicates(
+        subset=["useruuid", "loc"]
+    )
+    forward = {
+        (row.useruuid, row.loc): (row.lat_synth, row.lon_synth)
+        for row in per_loc.itertuples(index=False)
+    }
+    reverse = {
+        (row.useruuid, row.lat_synth, row.lon_synth): row.loc
+        for row in per_loc.itertuples(index=False)
+    }
+    return forward, reverse
+
+
+# ===========================================================================
+# Adapter 1: movingpandas home_location()
+# ===========================================================================
+def run_movingpandas_home_detection(stops_df, forward_lookup, reverse_lookup):
+    """One movingpandas Trajectory per user (one Point per STOP, not per raw
+    ping, indexed by stop start time). Returns dict[useruuid -> loc or None].
+    """
+    results = {}
+    for uid, g in stops_df.groupby("useruuid"):
+        g = g.sort_values("start")
+        if len(g) < 2:
+            results[uid] = None
+            continue
+        geometry = [
+            Point(forward_lookup[(uid, loc)][1], forward_lookup[(uid, loc)][0])
+            for loc in g["loc"]
+        ]
+        gdf = gpd.GeoDataFrame(
+            geometry=geometry,
+            index=pd.to_datetime(g["start"], unit="s"),
+            crs="EPSG:4326",
+        )
+        traj = mpd.Trajectory(gdf, traj_id=uid)
+        home_pt = mpd.MobilityMetricsCalculator(traj).home_location()
+        results[uid] = reverse_lookup.get((uid, home_pt.y, home_pt.x))
+    return results
+
+
+# ===========================================================================
+# Adapter 2: HoWDe HoWDe_labelling()
+# ===========================================================================
+def run_howde_home_detection(spark, stops_df, **config_overrides):
+    """Runs HoWDe with its own defaults (unless overridden) and reduces its
+    day-level `detect_H_loc` output to one label per user: the modal
+    non-null value across all days in the output. HoWDe's natural output is
+    per-day (a user's detected home can in principle drift over time); this
+    reduction is a deliberate simplification for a single-home comparison,
+    not something HoWDe itself does.
+
+    Returns dict[useruuid -> loc or None] plus the raw per-day pandas
+    DataFrame (useruuid, date, detect_H_loc), for inspecting non-detection
+    rates without re-running Spark.
+    """
+    cols = ["useruuid", "loc", "start", "end"]
+    if "country" in stops_df.columns:
+        cols.append("country")
+    sdf = spark.createDataFrame(stops_df[cols])
+
+    out = HoWDe_labelling(sdf, verbose=False, **config_overrides)
+    daily = out.select("useruuid", "date", "detect_H_loc").dropDuplicates().toPandas()
+
+    results = {}
+    for uid, g in daily.groupby("useruuid"):
+        non_null = g["detect_H_loc"].dropna()
+        results[uid] = non_null.mode().iloc[0] if len(non_null) else None
+    return results, daily
+
+
+# ===========================================================================
+# Weekly ground truth: user-week-level labels (useruuid, s_yy, s_woy, loc,
+# true_location_type), for datasets where ground truth is annotated per
+# week rather than once per user -- optional, off-repo data, never bundled
+# with this file.
+# ===========================================================================
+def load_weekly_stops_and_labels(max_users=WEEKLY_MAX_USERS, seed=42):
+    """Returns (stops_df, truelabels_wy_df).
+
+    stops_df: useruuid, loc, start, end -- same shape everything else in
+    this file expects.
+    truelabels_wy_df: useruuid, s_yy, s_woy, loc, true_location_type --
+    week-level ground truth, used as-is (no reduction to a single per-user
+    label, unlike the ground-truth section above).
+    """
+    if not WEEKLY_STOPS_PATH or not WEEKLY_TRUELABELS_PATH:
+        raise RuntimeError(
+            "Set WEEKLY_STOPS_PATH to a directory of parquet files with columns "
+            "useruuid, loc, start, end, and WEEKLY_TRUELABELS_PATH to a directory "
+            "with columns useruuid, s_yy, s_woy, loc, true_location_type."
+        )
+    stop_files = sorted(glob.glob(os.path.join(WEEKLY_STOPS_PATH, "*.parquet")))
+    label_files = sorted(glob.glob(os.path.join(WEEKLY_TRUELABELS_PATH, "*.parquet")))
+    if not stop_files:
+        raise FileNotFoundError(
+            f"No parquet files found in WEEKLY_STOPS_PATH={WEEKLY_STOPS_PATH}"
+        )
+    if not label_files:
+        raise FileNotFoundError(
+            f"No parquet files found in WEEKLY_TRUELABELS_PATH={WEEKLY_TRUELABELS_PATH}"
+        )
+
+    stops = pd.concat([pd.read_parquet(f) for f in stop_files], ignore_index=True)
+    # `loc` may be numeric in some exports; HoWDe internally casts it to a
+    # string, so its output always comes back as strings -- cast here too,
+    # up front, so every downstream merge on `loc` compares like types.
+    stops["loc"] = stops["loc"].astype(str)
+    stops = dedupe_stops(stops)
+    labels = pd.concat([pd.read_parquet(f) for f in label_files], ignore_index=True)
+    labels["loc"] = labels["loc"].astype(str)
+
+    all_users = sorted(stops["useruuid"].unique().tolist())
+    sample_users = (
+        all_users
+        if not max_users or max_users >= len(all_users)
+        else pd.Series(all_users).sample(n=max_users, random_state=seed).tolist()
+    )
+    stops = stops[stops["useruuid"].isin(sample_users)].reset_index(drop=True)
+    labels = labels[labels["useruuid"].isin(sample_users)].reset_index(drop=True)
+    return stops[["useruuid", "loc", "start", "end"]], labels
+
+
+def _week_year_columns(unix_start_series):
+    """s_yy = calendar year, s_woy = ISO week number, computed independently
+    from `start` (unix seconds), mirroring Spark's `F.year()` +
+    `F.weekofyear()` -- these two don't always agree at year boundaries
+    (e.g. Dec 30 2024 is ISO week 1 of 2025 but still gets s_yy=2024), kept
+    as-is rather than "fixed" so this matches how the ground-truth labels
+    were themselves built.
+    """
+    dt = pd.to_datetime(unix_start_series, unit="s")
+    return dt.dt.year, dt.dt.isocalendar().week.astype(int)
+
+
+def run_howde_weekly_labels(spark, stops_df, **config_overrides):
+    """Week-level output: useruuid, s_yy, s_woy, loc, location_type,
+    detect_H_loc -- HoWDe's day-level stop output, with s_yy/s_woy derived
+    from each stop's start time and duplicate (useruuid, s_yy, s_woy, loc,
+    location_type, detect_H_loc) combinations collapsed.
+    """
+    cols = ["useruuid", "loc", "start", "end"]
+    if "country" in stops_df.columns:
+        cols.append("country")
+    sdf = spark.createDataFrame(stops_df[cols])
+
+    out = HoWDe_labelling(sdf, verbose=False, **config_overrides)
+    wy = (
+        out.withColumn(
+            "s_woy", F.weekofyear(F.from_unixtime("start").cast("timestamp"))
+        )
+        .withColumn("s_yy", F.year(F.from_unixtime("start").cast("timestamp")))
+        .select("useruuid", "s_yy", "s_woy", "loc", "location_type", "detect_H_loc")
+        .dropDuplicates()
+    )
+    return wy.toPandas()
+
+
+def movingpandas_weekly_labels(stops_df, mpd_homes, target="H"):
+    """Week-level output for movingpandas: since home_location() only ever
+    produces ONE home for a user's entire history (no per-week
+    re-evaluation), that single pick is broadcast across every week the
+    user has stop data in -- "if you commit to this one answer, how often
+    is it right that week", not a claim that movingpandas does weekly
+    detection.
+    """
+    df = stops_df.copy()
+    df["s_yy"], df["s_woy"] = _week_year_columns(df["start"])
+    df["detect_H_loc"] = df["useruuid"].map(mpd_homes)
+    df["location_type"] = [
+        target if loc == home else "O"
+        for loc, home in zip(df["loc"], df["detect_H_loc"])
+    ]
+    return df[
+        ["useruuid", "s_yy", "s_woy", "loc", "location_type", "detect_H_loc"]
+    ].drop_duplicates()
+
+
+def evaluate_weekly_home_accuracy(detectlocs_wy, truelabels_wy, target="H"):
+    """Accuracy scored per user-week rather than per user: a true-target-
+    labeled user-week where that location wasn't actually visited that week
+    (so it never appears in `detectlocs_wy`) drops out of the comparison
+    entirely -- it can't be scored either way without a detection to
+    compare against.
+
+    detectlocs_wy: useruuid, s_yy, s_woy, loc, location_type, detect_H_loc
+    truelabels_wy: useruuid, s_yy, s_woy, loc, true_location_type
+
+    Returns dict(count, detected, acc, none) -- `acc`/`none` as percentages.
+    """
+    detect_col = f"detect_{target}_loc"
+    key = ["useruuid", "s_woy", "s_yy"]
+
+    # Step 1: did this user-week detect ANY target location at all (any day)?
+    has_detected = (
+        detectlocs_wy.groupby(key)[detect_col]
+        .apply(lambda s: bool(s.notna().any()))
+        .rename(f"hasdetected_{target}_uw")
+        .reset_index()
+    )
+
+    # Step 2: true target-labeled user-weeks, joined with the detection flag
+    true_target = truelabels_wy[truelabels_wy["true_location_type"] == target]
+    true_with_flag = true_target.merge(has_detected, on=key, how="inner")
+
+    # Step 3: one row per (useruuid, s_woy, s_yy, loc) -- prefer the row
+    # where this loc WAS the detected target that week (on any day), if any
+    labeled = detectlocs_wy.copy()
+    labeled["_is_target"] = labeled["loc"] == labeled[detect_col]
+    detect_per_loc = labeled.sort_values("_is_target", ascending=False).drop_duplicates(
+        subset=key + ["loc"], keep="first"
+    )
+
+    # Step 4: match true label to the resolved per-(week, loc) detection
+    matched = true_with_flag.merge(
+        detect_per_loc[key + ["loc", detect_col]], on=key + ["loc"], how="inner"
+    )
+    matched[f"match_{target}"] = matched["loc"] == matched[detect_col]
+
+    # Step 5: aggregate
+    count_ = len(matched)
+    detected_ = int(matched[f"hasdetected_{target}_uw"].sum())
+    match_sum = int(matched[f"match_{target}"].sum())
+    acc = 100 * match_sum / detected_ if detected_ else float("nan")
+    none_pct = 100 * (count_ - detected_) / count_ if count_ else float("nan")
+    return {"count": count_, "detected": detected_, "acc": acc, "none": none_pct}
+
+
+def compare_weekly_accuracy(spark, max_users=WEEKLY_MAX_USERS, seed=42):
+    stops_df, truelabels_wy = load_weekly_stops_and_labels(
+        max_users=max_users, seed=seed
+    )
+    forward, reverse = build_coord_lookup(stops_df, seed=seed)
+
+    mpd_homes = run_movingpandas_home_detection(stops_df, forward, reverse)
+    mpd_wy = movingpandas_weekly_labels(stops_df, mpd_homes)
+    mpd_metrics = evaluate_weekly_home_accuracy(mpd_wy, truelabels_wy)
+
+    howde_wy = run_howde_weekly_labels(spark, stops_df)
+    howde_metrics = evaluate_weekly_home_accuracy(howde_wy, truelabels_wy)
+
+    return mpd_metrics, howde_metrics
+
+
+# ===========================================================================
+# pytest -- synthetic (always runs; comparison assertions are HAVE_HOWDE-gated)
+# ===========================================================================
+def test_movingpandas_always_returns_a_home_even_on_gappy_data():
+    stops_df, _true_home = build_synthetic_stops("gappy")
+    forward, reverse = build_coord_lookup(stops_df)
+    result = run_movingpandas_home_detection(stops_df, forward, reverse)
+    assert result["synthetic_user"] is not None, (
+        "home_location() has no data-quality filter -- it should always "
+        "return a candidate, even from sparse data"
+    )
+
+
+def test_movingpandas_finds_correct_home_on_regular_pattern():
+    stops_df, true_home = build_synthetic_stops("regular")
+    forward, reverse = build_coord_lookup(stops_df)
+    result = run_movingpandas_home_detection(stops_df, forward, reverse)
+    assert result["synthetic_user"] == true_home
+
+
+@pytest.mark.skipif(not HAVE_HOWDE, reason="pip install pyspark HoWDe")
+def test_howde_finds_correct_home_on_regular_pattern(spark):
+    stops_df, true_home = build_synthetic_stops("regular")
+    result, _daily = run_howde_home_detection(spark, stops_df)
+    assert result["synthetic_user"] == true_home
+
+
+@pytest.mark.skipif(not HAVE_HOWDE, reason="pip install pyspark HoWDe")
+def test_howde_can_fail_to_detect_home_on_gappy_data(spark):
+    """HoWDe's data-quality gates (C_days_H, f_hours_H) mean it can
+    legitimately report NO home for some days when coverage is too sparse
+    -- movingpandas' home_location() has no equivalent concept and never
+    does this (see the companion test above).
+    """
+    stops_df, _true_home = build_synthetic_stops("gappy")
+    _result, daily = run_howde_home_detection(spark, stops_df)
+    assert daily["detect_H_loc"].isna().any(), (
+        "expected at least one day with no detected home on sparse data -- "
+        "if this fails, the gappy scenario needs to be sparser to actually "
+        "trigger HoWDe's C_days_H/f_hours_H gates"
+    )
+
+
+@pytest.mark.skipif(not HAVE_HOWDE, reason="pip install pyspark HoWDe")
+def test_ambiguous_nights_report_runs(spark, capsys):
+    """No single correct answer here by construction -- just confirm both
+    detectors run to completion and report what each picked, for the
+    __main__ report / -s output to show.
+    """
+    stops_df, _true_home = build_synthetic_stops("ambiguous_nights")
+    forward, reverse = build_coord_lookup(stops_df)
+    mpd_result = run_movingpandas_home_detection(stops_df, forward, reverse)
+    howde_result, _daily = run_howde_home_detection(spark, stops_df)
+    print(
+        f"\n[ambiguous_nights] movingpandas picked {mpd_result['synthetic_user']!r}, "
+        f"HoWDe picked {howde_result['synthetic_user']!r}"
+    )
+    assert mpd_result["synthetic_user"] in {"home_a", "home_b"}
+
+
+# ===========================================================================
+# pytest -- weekly ground truth (optional, off-repo data; skips cleanly if
+# WEEKLY_STOPS_PATH/WEEKLY_TRUELABELS_PATH aren't set)
+# ===========================================================================
+requires_weekly = pytest.mark.skipif(
+    not (HAVE_HOWDE and WEEKLY_STOPS_PATH and WEEKLY_TRUELABELS_PATH),
+    reason="set WEEKLY_STOPS_PATH and WEEKLY_TRUELABELS_PATH (needs pyspark/HoWDe too)",
+)
+
+
+@requires_weekly
+def test_weekly_accuracy_reported(spark, capsys):
+    """Descriptive (valid range, printed for eyeballing) -- prints both
+    methods' user-week accuracy/non-detection.
+    """
+    mpd_metrics, howde_metrics = compare_weekly_accuracy(spark)
+    assert 0 <= mpd_metrics["acc"] <= 100
+    assert 0 <= howde_metrics["acc"] <= 100
+    print(
+        f"\n[weekly] movingpandas: acc={mpd_metrics['acc']:.1f}% "
+        f"none={mpd_metrics['none']:.1f}%  (n={mpd_metrics['count']})"
+    )
+    print(
+        f"[weekly] HoWDe:        acc={howde_metrics['acc']:.1f}% "
+        f"none={howde_metrics['none']:.1f}%  (n={howde_metrics['count']})"
+    )
+
+
+# ===========================================================================
+# Standalone report
+# ===========================================================================
+if __name__ == "__main__":
+    # One SparkSession for the whole script -- repeatedly stop()/getOrCreate()
+    # in the same process is flaky (spurious "broken pipe" accumulator
+    # errors on shutdown), even though it doesn't affect correctness.
+    spark_session = _make_spark() if HAVE_HOWDE else None
+
+    print(f"\n{'#' * 70}\n# Synthetic scenarios\n{'#' * 70}")
+    for scenario in ["regular", "gappy", "ambiguous_nights"]:
+        stops_df, true_home = build_synthetic_stops(scenario)
+        forward, reverse = build_coord_lookup(stops_df)
+        mpd_result = run_movingpandas_home_detection(stops_df, forward, reverse)
+
+        print(f"\n--- scenario={scenario!r} (true_home={true_home!r}) ---")
+        print(f"movingpandas home_location(): {mpd_result['synthetic_user']!r}")
+
+        if HAVE_HOWDE:
+            howde_result, daily = run_howde_home_detection(spark_session, stops_df)
+            n_null_days = daily["detect_H_loc"].isna().sum()
+            print(
+                f"HoWDe HoWDe_labelling():      {howde_result['synthetic_user']!r} "
+                f"({n_null_days}/{len(daily)} days with no detected home)"
+            )
+        else:
+            print(
+                "[!] pyspark/HoWDe not installed -- pip install pyspark HoWDe to compare"
+            )
+
+    print(f"\n{'#' * 70}\n# Weekly ground truth (per-user-week accuracy)\n{'#' * 70}")
+    if not HAVE_HOWDE:
+        print("[!] pyspark/HoWDe not installed -- skipping. pip install pyspark HoWDe")
+    elif not (WEEKLY_STOPS_PATH and WEEKLY_TRUELABELS_PATH):
+        print(
+            "[!] WEEKLY_STOPS_PATH / WEEKLY_TRUELABELS_PATH not set -- skipping. e.g.:\n"
+            "    WEEKLY_STOPS_PATH=/path/to/stops WEEKLY_TRUELABELS_PATH=/path/to/truelabels_uwy \\\n"
+            "        python test_home_detection.py"
+        )
+    else:
+        print(
+            f"Sampling up to {WEEKLY_MAX_USERS or 'ALL'} users (set WEEKLY_MAX_USERS to change)"
+        )
+        mpd_metrics, howde_metrics = compare_weekly_accuracy(spark_session)
+        print(
+            f"\n{'method':<14}{'accuracy':>10}{'non-detected':>16}{'n user-weeks':>15}"
+        )
+        print(
+            f"{'movingpandas':<14}{mpd_metrics['acc']:>9.1f}%{mpd_metrics['none']:>15.1f}%{mpd_metrics['count']:>15}"
+        )
+        print(
+            f"{'HoWDe':<14}{howde_metrics['acc']:>9.1f}%{howde_metrics['none']:>15.1f}%{howde_metrics['count']:>15}"
+        )
+        print(
+            "\n(scored per user-week -- movingpandas' single whole-history home guess is "
+            "broadcast across every week it has data for)"
+        )
+
+    if spark_session is not None:
+        spark_session.stop()

--- a/movingpandas/tests/test_mobility_metrics_sdesojo.py
+++ b/movingpandas/tests/test_mobility_metrics_sdesojo.py
@@ -1,0 +1,802 @@
+"""Cross-validates 8 of the 9 functions in movingpandas' MobilityMetricsCalculator
+against independent, from-scratch reference implementations, to catch
+correctness bugs that a plain "does it run without crashing" test would miss.
+Written while testing movingpandas' MobilityMetricsCalculator
+(movingpandas/movingpandas#496).
+
+--------------------------------------------------------------------------
+WHAT'S TESTED
+--------------------------------------------------------------------------
+random_entropy, uncorrelated_entropy, waiting_times, radius_of_gyration,
+k_radius_of_gyration, jump_lengths, distance_straight_line, and
+real_entropy. `home_location` is intentionally NOT validated here -- it
+has its own dedicated test file.
+
+Every reference implementation lives in this one file, each verified
+against movingpandas' own source.
+
+Not every disagreement between movingpandas and the reference implementations
+here means a bug -- three different kinds of check:
+
+- EXACT: `random_entropy`, `uncorrelated_entropy`, `waiting_times`, and
+  `k_radius_of_gyration`'s location-selection logic are pure counting, no
+  distance formula involved anywhere -- any difference from the reference
+  is a real bug, not a rounding artifact.
+- TOLERANCE (~5%): `radius_of_gyration`, `jump_lengths`,
+  `distance_straight_line`, and `k_radius_of_gyration`'s distance value go
+  through movingpandas' geodesic (WGS84 ellipsoid) distance formula,
+  compared against a simpler spherical-law-of-cosines reference here -- a
+  small gap is EXPECTED and is not a bug; movingpandas' choice is the more
+  accurate one.
+- real_entropy is reported, not pass/fail: movingpandas' entropy estimator
+  uses a simplified boundary-term approximation that's expected to diverge
+  from a full estimator, especially on short sequences. This file reports
+  the relative gap and only sanity-checks it's finite and non-negative.
+
+--------------------------------------------------------------------------
+SETUP
+--------------------------------------------------------------------------
+    python3.10 -m venv .venv && source .venv/bin/activate
+    pip install pytest pandas numpy geopandas shapely \
+        "movingpandas @ git+https://github.com/movingpandas/movingpandas.git@skm"
+
+--------------------------------------------------------------------------
+RUN -- synthetic data (default; no extra setup, always runs)
+--------------------------------------------------------------------------
+    pytest tests/test_mobility_metrics.py -v   # edge cases + cross-validation
+    python tests/test_mobility_metrics.py         # prints a full report
+
+--------------------------------------------------------------------------
+RUN -- real coordinate data (skips cleanly unless REAL_STOPS_PATH is set)
+--------------------------------------------------------------------------
+Point REAL_STOPS_PATH at a CSV/parquet (or directory of *.parquet files)
+with genuine lat/lon -- columns: useruuid, loc, start (unix seconds),
+latitude, longitude. Assumes the input has no duplicate/colliding
+(useruuid, start) rows. Coordinates get canonicalized to the centroid
+of each (useruuid, loc)'s raw per-visit coordinates either way, same as
+the synthetic path:
+
+    REAL_STOPS_PATH=/path/to/stops.parquet REAL_MAX_USERS=25 \
+        pytest tests/test_mobility_metrics.py -v
+
+    REAL_STOPS_PATH=/path/to/stops.parquet REAL_MAX_USERS=0 \
+        python tests/test_mobility_metrics.py    # 0 = full dataset
+"""
+
+import glob
+import math
+import os
+import random
+from datetime import datetime, timedelta, timezone
+from math import acos, cos, radians, sin
+
+import geopandas as gpd
+import movingpandas as mpd
+import numpy as np
+import pandas as pd
+import pytest
+from shapely.geometry import Point
+
+pd.set_option("display.width", 200)
+pd.set_option("display.max_columns", 20)
+
+
+# ===========================================================================
+# Reference implementations -- pure Python, zero movingpandas dependency.
+# Each docstring says (a) which MobilityMetricsCalculator function it
+# validates, and (b) whether EXACT or TOLERANCE agreement is expected.
+# ===========================================================================
+def haversine_distance_m(lat1, lon1, lat2, lon2):
+    """Spherical law-of-cosines distance (same accuracy class as Haversine).
+    Backs every TOLERANCE-based reference below -- movingpandas uses
+    geodesic (GeoPy, WGS84 ellipsoid) distances instead, so a small gap vs.
+    this is EXPECTED, not a bug.
+    """
+    if lat1 == lat2 and lon1 == lon2:
+        return 0.0
+    km = (
+        acos(
+            sin(radians(lat1)) * sin(radians(lat2))
+            + cos(radians(lat1))
+            * cos(radians(lat2))
+            * cos(radians(lon1) - radians(lon2))
+        )
+        * 6371.0
+    )
+    return km * 1000.0
+
+
+def radius_of_gyration_m(points):
+    """points: list of (lat, lon). Reference for
+    MobilityMetricsCalculator.radius_of_gyration() -- TOLERANCE (geodesic
+    gap). Verified against movingpandas' source: plain centroid of all
+    points, RMS distance from it.
+    """
+    n = len(points)
+    if n == 0:
+        return 0.0
+    center_lat = sum(p[0] for p in points) / n
+    center_lon = sum(p[1] for p in points) / n
+    sq_distances = [
+        haversine_distance_m(lat, lon, center_lat, center_lon) ** 2
+        for lat, lon in points
+    ]
+    return math.sqrt(sum(sq_distances) / n)
+
+
+def jump_lengths_m(points):
+    """points: ordered list of (lat, lon). Reference for
+    MobilityMetricsCalculator.jump_lengths() -- TOLERANCE (geodesic gap).
+    """
+    return [
+        haversine_distance_m(
+            points[i - 1][0], points[i - 1][1], points[i][0], points[i][1]
+        )
+        for i in range(1, len(points))
+    ]
+
+
+def distance_straight_line_m(points):
+    """points: ordered list of (lat, lon). Reference for
+    MobilityMetricsCalculator.distance_straight_line() -- TOLERANCE
+    (geodesic gap). movingpandas computes this via traj.get_length(), which
+    is the same sum-of-consecutive-distances definition.
+    """
+    return sum(jump_lengths_m(points))
+
+
+def k_radius_of_gyration_ref(points, k=2):
+    """points: TIME-ORDERED list of (lat, lon), one entry per visit (NOT
+    deduplicated -- order and repetition both matter here). Reference for
+    MobilityMetricsCalculator.k_radius_of_gyration().
+
+    Verified line-by-line against movingpandas' source: build visit counts
+    via a single pass over `points` (so a location's position in the counts
+    dict is its first chronological occurrence), take the top-k by count
+    with a plain descending sort (Python's sorted() is stable, so ties keep
+    their first-occurrence relative order -- this is k_radius_of_gyration's
+    tie-break rule), then the "center" is the WEIGHTED mean of the top-k
+    locations (each location's coords repeated by its own visit count
+    before averaging -- not a plain centroid of k points), and the RMS
+    distance is computed over that same repeated/expanded list.
+
+    Returns (selected: set of (lat, lon) -- EXACT-match check, rms_m: float
+    -- TOLERANCE check, geodesic gap).
+    """
+    counts = {}
+    for pt in points:
+        counts[pt] = counts.get(pt, 0) + 1
+    top_k = sorted(counts.items(), key=lambda kv: kv[1], reverse=True)[:k]
+    expanded = [pt for pt, n in top_k for _ in range(n)]
+    center_lat = sum(p[0] for p in expanded) / len(expanded)
+    center_lon = sum(p[1] for p in expanded) / len(expanded)
+    sq = [
+        haversine_distance_m(lat, lon, center_lat, center_lon) ** 2
+        for lat, lon in expanded
+    ]
+    rms_m = math.sqrt(sum(sq) / len(sq))
+    selected = {pt for pt, _ in top_k}
+    return selected, rms_m
+
+
+def shannon_entropy(seq):
+    """seq: sequence of hashable location ids/coords. Reference for
+    MobilityMetricsCalculator.uncorrelated_entropy() -- EXACT (pure
+    counting, no distance formula involved).
+    """
+    n = len(seq)
+    if n == 0:
+        return 0.0
+    counts = {}
+    for v in seq:
+        counts[v] = counts.get(v, 0) + 1
+    entropy = 0.0
+    for c in counts.values():
+        p = c / n
+        entropy -= p * math.log2(p)
+    return entropy
+
+
+def random_entropy_ref(seq):
+    """seq: sequence of hashable location ids/coords. Reference for
+    MobilityMetricsCalculator.random_entropy() -- EXACT (log2 of a plain
+    distinct-value count, no distance formula anywhere).
+    """
+    n_unique = len(set(seq))
+    return math.log2(n_unique) if n_unique > 0 else 0.0
+
+
+def waiting_times_ref(timestamps):
+    """timestamps: TIME-ORDERED list of datetimes. Reference for
+    MobilityMetricsCalculator.waiting_times() -- EXACT (elapsed time
+    between consecutive rows, no distance/location logic at all).
+    """
+    return [
+        (timestamps[i] - timestamps[i - 1]).total_seconds()
+        for i in range(1, len(timestamps))
+    ]
+
+
+def _lempel_ziv_lambda(seq, i):
+    """Length of the shortest substring starting at i that has not
+    previously occurred in seq[:i] (Song et al. 2010 / Kontoyiannis et al.
+    1998 estimator, the FULL version -- see lempel_ziv_entropy below for why
+    this is expected to diverge from movingpandas' real_entropy()).
+    """
+    n = len(seq)
+    seq = seq + ["__terminate__"]
+    x = 1
+    matches = [idx for idx, val in enumerate(seq[:i]) if val == seq[i]]
+    while matches and x <= n - i:
+        if matches[-1] + x >= i:
+            del matches[-1]
+        matches = [idx for idx in matches if seq[idx + x] == seq[i + x]]
+        x += 1
+    return x
+
+
+def lempel_ziv_entropy(seq):
+    """Reference for MobilityMetricsCalculator.real_entropy() -- NOT
+    pass/fail. This is a FULL Lempel-Ziv estimator (computes real Lambda_i
+    at every index); movingpandas' `_true_entropy()` hardcodes a constant
+    (`sum_lambda = 3.0`) for the sequence's first/last terms instead of
+    computing them -- deliberate on their side, but it means divergence
+    from this reference is EXPECTED, especially on short sequences (n=2
+    always makes movingpandas' constant the entire computation). Report the
+    gap; don't assert tight equality.
+    """
+    n = len(seq)
+    if n <= 1:
+        return 0.0
+    lambdas = [_lempel_ziv_lambda(seq, i) for i in range(n)]
+    return n / sum(lambdas) * math.log2(n)
+
+
+# ===========================================================================
+# Synthetic data: 5 named locations, jittered per visit (so canonicalization
+# is required to satisfy movingpandas' identical-Point-geometry precondition
+# -- see canonicalize_locations() below), several regular users, plus one
+# edge case.
+# ===========================================================================
+TRUE_LOCS = {
+    "home_A": (48.2082, 16.3738),
+    "work_B": (48.1867, 16.3378),
+    "cafe_C": (48.2100, 16.3900),
+    "gym_D": (48.1950, 16.3600),
+    "shop_E": (48.2200, 16.3500),
+}
+
+
+def _jitter(lat, lon, rng, spread=0.0001):
+    # ~10m of GPS noise per visit -- real stop detectors won't return
+    # byte-identical coordinates for repeat visits to the same place.
+    return lat + rng.uniform(-spread, spread), lon + rng.uniform(-spread, spread)
+
+
+def build_synthetic_stops(seed=42):
+    """Returns a DataFrame: useruuid, start (unix s), loc, latitude,
+    longitude. Every metric's cross-validation below runs against this.
+    """
+    rng = random.Random(seed)
+    rows = []
+    start_day = datetime(2024, 3, 4, tzinfo=timezone.utc)  # a Monday
+
+    # --- Regular users: repeating daily pattern, home (night) -> day activity ---
+    patterns = {
+        "u1": ["home_A", "work_B", "work_B", "home_A"],
+        "u2": ["home_A", "cafe_C", "work_B", "home_A"],
+        "u3": ["home_A", "work_B", "gym_D", "home_A"],
+        "u4": ["home_A", "shop_E", "home_A"],
+        "u5": ["home_A", "work_B", "cafe_C", "work_B", "gym_D", "shop_E", "home_A"],
+    }
+    for user, seq in patterns.items():
+        for day in range(4):
+            t = start_day + timedelta(days=day, hours=23)  # start at 23:00
+            for loc_name in seq:
+                lat, lon = _jitter(*TRUE_LOCS[loc_name], rng)
+                rows.append(
+                    {
+                        "useruuid": user,
+                        "start": t.timestamp(),
+                        "loc": loc_name,
+                        "latitude": lat,
+                        "longitude": lon,
+                    }
+                )
+                t += timedelta(hours=rng.randint(1, 4))
+
+    # --- Edge case: single-stop user (jump_lengths/waiting_times n=0 case) ---
+    lat, lon = _jitter(*TRUE_LOCS["home_A"], rng)
+    rows.append(
+        {
+            "useruuid": "single",
+            "start": start_day.timestamp(),
+            "loc": "home_A",
+            "latitude": lat,
+            "longitude": lon,
+        }
+    )
+
+    return pd.DataFrame(rows)
+
+
+# ===========================================================================
+# Real data: same shape as build_synthetic_stops() (useruuid, start, loc,
+# latitude, longitude), so canonicalize_locations()/build_trajectory_collection()/
+# run_all_metrics()/cross_validate() below are reused UNCHANGED for real
+# data -- only loading differs.
+# ===========================================================================
+REAL_STOPS_PATH = os.environ.get("REAL_STOPS_PATH")
+REAL_MAX_USERS = int(os.environ.get("REAL_MAX_USERS", 25))
+REQUIRED_REAL_COLS = {"useruuid", "loc", "start", "latitude", "longitude"}
+
+
+def _read_any(path):
+    if os.path.isdir(path):
+        files = sorted(glob.glob(os.path.join(path, "*.parquet")))
+        if not files:
+            raise FileNotFoundError(f"No parquet files found under {path}")
+        return pd.concat([pd.read_parquet(f) for f in files], ignore_index=True)
+    if path.endswith(".parquet"):
+        return pd.read_parquet(path)
+    return pd.read_csv(path)
+
+
+def load_real_stops(path=None, max_users=None, seed=42):
+    """Returns a DataFrame: useruuid, start (unix s), loc, latitude,
+    longitude -- same shape build_synthetic_stops() returns, so every
+    downstream function (canonicalize_locations, build_trajectory_collection,
+    run_all_metrics, cross_validate) works on either without modification.
+    """
+    path = path or REAL_STOPS_PATH
+    max_users = REAL_MAX_USERS if max_users is None else max_users
+    if not path:
+        raise RuntimeError(
+            "Set REAL_STOPS_PATH to a CSV/parquet (or directory of *.parquet) with "
+            "columns: useruuid, loc, start, latitude, longitude. Assumes the input "
+            "has no duplicate/colliding (useruuid, start) rows -- dedupe "
+            "upstream if needed."
+        )
+    df = _read_any(path)
+    missing = REQUIRED_REAL_COLS - set(df.columns)
+    if missing:
+        raise ValueError(f"Input is missing required columns: {missing}")
+
+    all_users = sorted(df["useruuid"].unique().tolist())
+    if max_users and max_users < len(all_users):
+        sample = pd.Series(all_users).sample(n=max_users, random_state=seed).tolist()
+        df = df[df["useruuid"].isin(sample)]
+
+    return df[["useruuid", "start", "loc", "latitude", "longitude"]].reset_index(
+        drop=True
+    )
+
+
+def canonicalize_locations(df):
+    """Assign every visit to the same (useruuid, loc) an identical (lat,
+    lon) -- the centroid of its raw per-visit coordinates. Required because
+    MobilityMetricsCalculator groups points by exact Point equality, so
+    repeat visits to the same place need byte-identical coordinates to be
+    recognized as the same location.
+    """
+    canon = (
+        df.groupby(["useruuid", "loc"])[["latitude", "longitude"]]
+        .mean()
+        .rename(columns={"latitude": "lat_canon", "longitude": "lon_canon"})
+    )
+    return df.join(canon, on=["useruuid", "loc"])
+
+
+def build_trajectory_collection(df):
+    df = canonicalize_locations(df).sort_values(["useruuid", "start"])
+    geometry = [Point(lon, lat) for lat, lon in zip(df["lat_canon"], df["lon_canon"])]
+    index = pd.to_datetime(df["start"], unit="s")
+    gdf = gpd.GeoDataFrame(
+        {"useruuid": df["useruuid"].to_numpy()},
+        geometry=geometry,
+        index=index,
+        crs="EPSG:4326",
+    )
+    return mpd.TrajectoryCollection(gdf, traj_id_col="useruuid")
+
+
+# ===========================================================================
+# Run all 9 functions (home_location included for completeness -- see
+# module docstring for why it's excluded from cross-validation below) +
+# cross-validate the other 8 against the references above.
+# ===========================================================================
+def run_all_metrics(collection):
+    calc = mpd.MobilityMetricsCalculator(collection)
+    return {
+        "radius_of_gyration": calc.radius_of_gyration(),
+        "k_radius_of_gyration": calc.k_radius_of_gyration(k=2),
+        "jump_lengths": calc.jump_lengths(),
+        "waiting_times": calc.waiting_times(),
+        "home_location": calc.home_location(),
+        "random_entropy": calc.random_entropy(),
+        "uncorrelated_entropy": calc.uncorrelated_entropy(),
+        "real_entropy": calc.real_entropy(),
+        "distance_straight_line": calc.distance_straight_line(),
+    }
+
+
+def cross_validate(df, results):
+    """One row per user with every IN-SCOPE metric's mpd-vs-reference diff
+    (home_location excluded -- see module docstring). EXACT columns should
+    all read (numerically) zero; TOLERANCE columns are relative diffs
+    expected to stay within a few percent; real_entropy is reported only,
+    not judged.
+    """
+    canon = canonicalize_locations(df).sort_values(["useruuid", "start"])
+    rows = []
+    for user, g in canon.groupby("useruuid"):
+        if user not in results["uncorrelated_entropy"].index:
+            # single-point users are silently dropped by
+            # movingpandas' TrajectoryCollection
+            continue
+        loc_seq = g["loc"].tolist()
+        points = list(zip(g["lat_canon"], g["lon_canon"]))
+        timestamps = pd.to_datetime(g["start"], unit="s").tolist()
+
+        ref_uncor = shannon_entropy(loc_seq)
+        ref_rand = random_entropy_ref(loc_seq)
+        ref_real = lempel_ziv_entropy(loc_seq)
+        ref_rog = radius_of_gyration_m(points)
+        ref_dsl = distance_straight_line_m(points)
+        ref_jumps = jump_lengths_m(points)
+        ref_waits = waiting_times_ref(timestamps)
+        _ref_kloc_selected, ref_kloc_rms = k_radius_of_gyration_ref(
+            points, k=2
+        )  # selection unused here, see NOTE below
+
+        mpd_jumps = results["jump_lengths"][user]
+        mpd_waits = results["waiting_times"][user]
+
+        rows.append(
+            {
+                "useruuid": user,
+                "n_stops": len(g),
+                "n_unique_locs": g["loc"].nunique(),
+                # --- EXACT-match metrics ---
+                "uncorrelated_entropy_diff": results["uncorrelated_entropy"][user]
+                - ref_uncor,
+                "random_entropy_diff": results["random_entropy"][user] - ref_rand,
+                "waiting_times_max_abs_diff": max(
+                    (abs(a - b) for a, b in zip(mpd_waits, ref_waits)), default=0.0
+                ),
+                # NOTE: k_radius_of_gyration's *selection* (which locations
+                # count as the top-k) has no public accessor --
+                # calc.k_radius_of_gyration()
+                # only returns the resulting RMS distance, never the set of
+                # selected locations. So on bulk/random data, selection
+                # agreement can only be checked INDIRECTLY, via the distance
+                # tolerance check below (a different selection would very
+                # likely produce a different RMS distance) -- there is no
+                # second, independent way to assert it exactly here. The
+                # dedicated tie-break test further down constructs a
+                # scenario precise enough to verify the *selection* itself,
+                # not just the resulting distance.
+                # --- TOLERANCE metrics (geodesic vs. spherical gap expected) ---
+                "radius_of_gyration_reldiff": (
+                    abs(results["radius_of_gyration"][user] - ref_rog) / ref_rog
+                    if ref_rog
+                    else float("nan")
+                ),
+                "distance_straight_line_reldiff": (
+                    abs(results["distance_straight_line"][user] - ref_dsl) / ref_dsl
+                    if ref_dsl
+                    else float("nan")
+                ),
+                "jump_lengths_max_reldiff": max(
+                    (
+                        abs(a - b) / b if b else 0.0
+                        for a, b in zip(mpd_jumps, ref_jumps)
+                    ),
+                    default=0.0,
+                ),
+                "k_radius_distance_reldiff": (
+                    abs(results["k_radius_of_gyration"][user] - ref_kloc_rms)
+                    / ref_kloc_rms
+                    if ref_kloc_rms
+                    else float("nan")
+                ),
+                # --- reported, not judged ---
+                "real_entropy_reldiff": (
+                    abs(results["real_entropy"][user] - ref_real) / ref_real
+                    if ref_real
+                    else float("nan")
+                ),
+            }
+        )
+    return pd.DataFrame(rows).set_index("useruuid")
+
+
+# ===========================================================================
+# pytest -- bulk cross-validation (all users, all in-scope metrics, one pass)
+# ===========================================================================
+EXACT_TOL = 1e-9
+DISTANCE_TOL = 0.05  # 5% -- generous enough to absorb the geodesic-vs-spherical
+# formula gap (see module docstring)
+
+
+@pytest.fixture(scope="module")
+def diffs():
+    df = build_synthetic_stops()
+    results = run_all_metrics(build_trajectory_collection(df))
+    return cross_validate(df, results)
+
+
+def test_all_metrics_run_without_error():
+    # home_location is included here (it does need to at least RUN without
+    # crashing) even though its correctness is validated elsewhere -- see
+    # module docstring.
+    df = build_synthetic_stops()
+    results = run_all_metrics(build_trajectory_collection(df))
+    assert set(results) == {
+        "radius_of_gyration",
+        "k_radius_of_gyration",
+        "jump_lengths",
+        "waiting_times",
+        "home_location",
+        "random_entropy",
+        "uncorrelated_entropy",
+        "real_entropy",
+        "distance_straight_line",
+    }
+
+
+def test_single_stop_user_is_dropped_silently():
+    # movingpandas silently drops single-point trajectories -- not this
+    # file's bug to fix
+    df = build_synthetic_stops()
+    results = run_all_metrics(build_trajectory_collection(df))
+    assert "single" not in results["uncorrelated_entropy"].index
+
+
+# --- EXACT-match assertions ---
+def test_uncorrelated_entropy_matches_reference_exactly(diffs):
+    assert diffs["uncorrelated_entropy_diff"].abs().max() < EXACT_TOL
+
+
+def test_random_entropy_matches_reference_exactly(diffs):
+    assert diffs["random_entropy_diff"].abs().max() < EXACT_TOL
+
+
+def test_waiting_times_matches_reference_exactly(diffs):
+    assert diffs["waiting_times_max_abs_diff"].max() < EXACT_TOL
+
+
+# k_radius_of_gyration's *selection* has no dedicated bulk exact-match test
+# here -- see the NOTE in cross_validate() above for why (no public
+# accessor for which locations were selected). Its distance-tolerance test
+# below is the closest bulk check; test_k_radius_of_gyration_tie_break_...
+# further down verifies selection itself, in a scenario precise enough to do so.
+
+
+# --- TOLERANCE assertions (geodesic vs. spherical gap expected, see docstring) ---
+def test_radius_of_gyration_within_geodesic_tolerance(diffs):
+    assert diffs["radius_of_gyration_reldiff"].max() < DISTANCE_TOL
+
+
+def test_distance_straight_line_within_geodesic_tolerance(diffs):
+    assert diffs["distance_straight_line_reldiff"].max() < DISTANCE_TOL
+
+
+def test_jump_lengths_within_geodesic_tolerance(diffs):
+    assert diffs["jump_lengths_max_reldiff"].max() < DISTANCE_TOL
+
+
+def test_k_radius_of_gyration_distance_within_geodesic_tolerance(diffs):
+    assert diffs["k_radius_distance_reldiff"].max() < DISTANCE_TOL
+
+
+# --- real_entropy: reported, not judged (see module docstring) ---
+def test_real_entropy_is_finite_and_nonnegative(diffs):
+    df = build_synthetic_stops()
+    results = run_all_metrics(build_trajectory_collection(df))
+    assert (results["real_entropy"] >= 0).all()
+    assert np.isfinite(results["real_entropy"]).all()
+
+
+# ===========================================================================
+# Dedicated tie-break test -- built on a minimal, hand-verified Trajectory
+# (not the bulk synthetic dataset), because a tie-break rule needs a
+# precisely-controlled scenario, not a statistically-likely one.
+# ===========================================================================
+def test_k_radius_of_gyration_tie_break_prefers_first_chronological_occurrence():
+    """Hand-built trajectory, exact (non-jittered) coordinates: R visited
+    3x, P visited 2x (first occurrence at t=1), Q visited 2x (first
+    occurrence at t=2, strictly after P's). With k=2: R is rank 1 outright;
+    P and Q are tied for rank 2 at 2 visits each. movingpandas'
+    k_radius_of_gyration builds visit counts via a single time-ordered pass
+    then does a plain stable sort by count descending -- ties keep their
+    original (= first-occurrence) relative order, so P (seen first) must
+    be selected over Q, even though nothing about P's *count* was ever
+    higher than Q's.
+    """
+    R, P, Q = (48.20, 16.37), (48.21, 16.38), (48.19, 16.36)
+    sequence = [
+        R,
+        P,
+        Q,
+        R,
+        P,
+        Q,
+        R,
+    ]  # P's first occurrence (idx 1) precedes Q's (idx 2)
+    times = pd.date_range("2024-01-01", periods=len(sequence), freq="1h")
+    gdf = gpd.GeoDataFrame(
+        {"geometry": [Point(lon, lat) for lat, lon in sequence]},
+        index=times,
+        crs="EPSG:4326",
+    )
+    traj = mpd.Trajectory(gdf, traj_id="tie_kradius")
+    calc = mpd.MobilityMetricsCalculator(traj)
+
+    ref_selected, _ = k_radius_of_gyration_ref(sequence, k=2)
+    assert ref_selected == {
+        R,
+        P,
+    }, (
+        "sanity-check the reference implementation's own tie-break "
+        "before trusting it as ground truth"
+    )
+
+    # movingpandas doesn't expose *which* locations were selected directly,
+    # so we assert indirectly: k_radius_of_gyration(k=2) must equal
+    # radius_of_gyration() computed over just {R, P} at their true
+    # visit-weighted multiplicity (3x R, 2x P) -- if movingpandas had
+    # picked Q instead of P, this would not match.
+    expected_points_if_P_selected = [R, R, R, P, P]
+    expected_rms = radius_of_gyration_m(expected_points_if_P_selected)
+    got = calc.k_radius_of_gyration(k=2)
+    assert abs(got - expected_rms) / expected_rms < DISTANCE_TOL
+
+
+# ===========================================================================
+# pytest -- real coordinate data (skips cleanly unless REAL_STOPS_PATH is
+# set). Same EXACT/TOLERANCE split as the synthetic tests above, just
+# parametrized over the diff columns instead of one function per metric --
+# avoids duplicating 7 near-identical function bodies for a second data
+# source; pytest still reports each metric's pass/fail individually via the
+# parametrized test id (e.g. test_real_exact_match_metric[random_entropy_diff]).
+# ===========================================================================
+pytestmark_real = pytest.mark.skipif(
+    not REAL_STOPS_PATH,
+    reason="REAL_STOPS_PATH not set -- no real-coordinate dataset available yet",
+)
+
+EXACT_MATCH_COLUMNS = [
+    "uncorrelated_entropy_diff",
+    "random_entropy_diff",
+    "waiting_times_max_abs_diff",
+]
+TOLERANCE_COLUMNS = [
+    "radius_of_gyration_reldiff",
+    "distance_straight_line_reldiff",
+    "jump_lengths_max_reldiff",
+    "k_radius_distance_reldiff",
+]
+
+
+@pytest.fixture(scope="module")
+def diffs_real():
+    df = load_real_stops()
+    results = run_all_metrics(build_trajectory_collection(df))
+    return cross_validate(df, results)
+
+
+@pytestmark_real
+def test_real_all_metrics_run_without_error():
+    df = load_real_stops()
+    results = run_all_metrics(build_trajectory_collection(df))
+    assert set(results) == {
+        "radius_of_gyration",
+        "k_radius_of_gyration",
+        "jump_lengths",
+        "waiting_times",
+        "home_location",
+        "random_entropy",
+        "uncorrelated_entropy",
+        "real_entropy",
+        "distance_straight_line",
+    }
+
+
+@pytestmark_real
+@pytest.mark.parametrize("col", EXACT_MATCH_COLUMNS)
+def test_real_exact_match_metric(diffs_real, col):
+    assert diffs_real[col].abs().max() < EXACT_TOL
+
+
+@pytestmark_real
+@pytest.mark.parametrize("col", TOLERANCE_COLUMNS)
+def test_real_metric_within_geodesic_tolerance(diffs_real, col):
+    assert diffs_real[col].max() < DISTANCE_TOL
+
+
+@pytestmark_real
+def test_real_entropy_divergence_shrinks_on_longer_sequences(diffs_real):
+    """real_entropy()'s boundary-term approximation biases short sequences
+    most -- on real data (typically far longer than the synthetic fixture's
+    ~16-28 stops/user), the median relative gap for longer-sequence users
+    should be much smaller than on tiny synthetic edge cases. Not pass/fail
+    on an exact number, just confirms the divergence shrinks with sequence
+    length on real data too.
+    """
+    long_enough = diffs_real[diffs_real["n_stops"] >= 20]
+    if len(long_enough):
+        assert long_enough["real_entropy_reldiff"].median() < 0.05
+
+
+# ===========================================================================
+# Standalone report
+# ===========================================================================
+def _print_cross_validation_report(diffs_df):
+    print("\n=== EXACT-match metrics (any nonzero diff is a real bug) ===")
+    print(diffs_df[EXACT_MATCH_COLUMNS].round(6).to_string())
+
+    print(
+        f"\n=== TOLERANCE metrics (geodesic vs. spherical gap, expect < "
+        f"{DISTANCE_TOL:.0%}) ==="
+    )
+    print(diffs_df[TOLERANCE_COLUMNS].round(4).to_string())
+
+    print(
+        "\n=== real_entropy (reported only -- divergence from a full Lempel-Ziv "
+        "estimator is expected on short sequences) ==="
+    )
+    print(diffs_df[["n_stops", "real_entropy_reldiff"]].round(4).to_string())
+
+
+if __name__ == "__main__":
+    using_real = bool(REAL_STOPS_PATH)
+    print(
+        f"\n########## Comprehensive MobilityMetricsCalculator validation "
+        f"({'REAL' if using_real else 'SYNTHETIC'} data) ##########"
+    )
+    print("(home_location is out of scope here -- see module docstring)")
+
+    if using_real:
+        print(
+            f"\nLoading from {REAL_STOPS_PATH!r}, sampling up to "
+            f"{REAL_MAX_USERS or 'all'} users"
+        )
+        df = load_real_stops()
+    else:
+        df = build_synthetic_stops()
+    print(
+        f"\n{len(df)} stops, {df['useruuid'].nunique()} users"
+        + ("" if using_real else " (incl. the 'single' edge case)")
+    )
+
+    collection = build_trajectory_collection(df)
+    n_single = df["useruuid"].nunique() - len(collection.trajectories)
+    print(
+        f"Built {len(collection.trajectories)} trajectories "
+        f"({n_single} single-point user(s) dropped)"
+    )
+
+    results = run_all_metrics(collection)
+    diffs_df = cross_validate(df, results)
+    _print_cross_validation_report(diffs_df)
+
+    print(
+        "\n=== k_radius_of_gyration tie-break check (synthetic, hand-built -- "
+        "independent of data source above) ==="
+    )
+    R, P, Q = (48.20, 16.37), (48.21, 16.38), (48.19, 16.36)
+    seq = [R, P, Q, R, P, Q, R]
+    tie_gdf = gpd.GeoDataFrame(
+        {"geometry": [Point(lon, lat) for lat, lon in seq]},
+        index=pd.date_range("2024-01-01", periods=len(seq), freq="1h"),
+        crs="EPSG:4326",
+    )
+    tie_calc = mpd.MobilityMetricsCalculator(
+        mpd.Trajectory(tie_gdf, traj_id="tie_kradius")
+    )
+    print(
+        f"k_radius_of_gyration(k=2) tie-break (P vs Q, equal counts, "
+        f"P seen first): {tie_calc.k_radius_of_gyration(k=2):.2f}m "
+        f"-- expected {radius_of_gyration_m([R, R, R, P, P]):.2f}m (P selected, not Q)"
+    )

--- a/movingpandas/tests/test_stop_detection_comparison.py
+++ b/movingpandas/tests/test_stop_detection_comparison.py
@@ -1,0 +1,994 @@
+"""Tests a core question: does movingpandas' TrajectoryStopDetector produce
+a stop list where revisits to the same physical place share a location id
+and identical coordinates -- and how does that compare to InfoStop, which
+is explicitly built to do that?
+
+--------------------------------------------------------------------------
+FINDINGS
+--------------------------------------------------------------------------
+1. TrajectoryStopDetector.get_stop_points() gives one row per VISIT, never
+   per LOCATION. There is no location-id column at all -- its `stop_id` is
+   `f'{traj_id}_{start_time}'`, unique per visit by construction.
+2. Two visits to the literal same physical place get independently
+   computed centroids (median of that visit's own raw pings) that are
+   close, but NOT identical.
+3. InfoStop's `loc` (an Infomap community label) IS a location id: every
+   visit sharing a `loc` gets the SAME coordinate, because it comes from
+   `compute_label_medians()` -- one canonical value per label, not
+   recomputed per visit.
+4. Downstream consequence: feeding TrajectoryStopDetector's own output
+   straight into movingpandas' own MobilityMetricsCalculator inflates
+   entropy metrics, because every revisit looks like a new location.
+5. TrajectoryStopDetector has no gap-length protection -- a multi-day data
+   gap bracketed by two short stays at the same place is silently reported
+   as ONE stop spanning the entire gap. InfoStop's `max_time_between`
+   splits it into two correctly-short stays that still get linked to the
+   same `loc`.
+
+Self-contained on purpose: no imports from anything else in this repo, so
+this single file can be handed to a colleague and run on its own.
+
+--------------------------------------------------------------------------
+SETUP
+--------------------------------------------------------------------------
+    python3.10 -m venv .venv && source .venv/bin/activate
+    pip install pytest pandas numpy geopandas shapely \
+        "movingpandas @ git+https://github.com/movingpandas/movingpandas.git@skm"
+    pip install infostop   # optional: InfoStop-comparison tests skip cleanly
+                            # without it, but you want it installed to see
+                            # the actual point of this file.
+
+--------------------------------------------------------------------------
+RUN -- synthetic data (default; no extra setup, safe to run anywhere)
+--------------------------------------------------------------------------
+    pytest test_stop_detection_comparison.py -v
+    python test_stop_detection_comparison.py              # prints a full report
+
+--------------------------------------------------------------------------
+RUN -- real data
+--------------------------------------------------------------------------
+Both detectors need DENSE RAW GPS PINGS as input, not pre-aggregated stops
+(that's the whole thing being tested -- stop detection itself). Point
+REAL_PINGS_PATH at a CSV/parquet (or directory of *.parquet files) with
+columns: useruuid, latitude, longitude, timestamp (unix seconds).
+
+Detection parameters are also env-overridable; the defaults below were
+tuned/validated on synthetic Vienna-scale data (~100m stay radius, ~20min
+minimum stay) -- re-tune to match your data's actual GPS noise and expected
+stay durations before trusting the numbers on real data:
+
+    REAL_PINGS_PATH=/path/to/pings.parquet \
+    REAL_MAX_USERS=25 \
+    MPD_MAX_DIAMETER_M=100 MPD_MIN_DURATION_MIN=20 \
+    INFOSTOP_R1_M=100 INFOSTOP_R2_M=100 \
+    INFOSTOP_MIN_STAYING_S=1200 INFOSTOP_MAX_TIME_BETWEEN_S=86400 \
+    INFOSTOP_MIN_SIZE=2 \
+        pytest test_stop_detection_comparison.py -v
+
+    (same env vars) python test_stop_detection_comparison.py    # prints a full report
+
+REAL_MAX_USERS=0 runs every user in the file (default samples 25).
+"""
+
+import glob
+import os
+import random
+from datetime import timedelta
+from pathlib import Path
+
+import geopandas as gpd
+import movingpandas as mpd
+import numpy as np
+import pandas as pd
+import pytest
+from shapely.geometry import Point
+
+try:
+    from infostop import Infostop
+
+    HAVE_INFOSTOP = True
+except ImportError:
+    HAVE_INFOSTOP = False
+
+try:
+    import matplotlib
+
+    matplotlib.use("Agg")  # save to file, no display needed
+    import matplotlib.pyplot as plt
+
+    HAVE_MATPLOTLIB = True
+except ImportError:
+    HAVE_MATPLOTLIB = False
+
+pd.set_option("display.width", 200)
+pd.set_option("display.max_columns", 20)
+
+# ===========================================================================
+# Config -- env-overridable, same knobs for synthetic and real data
+# ===========================================================================
+MPD_MAX_DIAMETER_M = float(os.environ.get("MPD_MAX_DIAMETER_M", 100))
+MPD_MIN_DURATION = timedelta(minutes=float(os.environ.get("MPD_MIN_DURATION_MIN", 20)))
+
+INFOSTOP_R1_M = float(os.environ.get("INFOSTOP_R1_M", 100))
+INFOSTOP_R2_M = float(os.environ.get("INFOSTOP_R2_M", 100))
+INFOSTOP_MIN_STAYING_S = float(os.environ.get("INFOSTOP_MIN_STAYING_S", 1200))
+INFOSTOP_MAX_TIME_BETWEEN_S = float(
+    os.environ.get("INFOSTOP_MAX_TIME_BETWEEN_S", 86400)
+)
+INFOSTOP_MIN_SIZE = int(os.environ.get("INFOSTOP_MIN_SIZE", 2))
+
+REAL_PINGS_PATH = os.environ.get("REAL_PINGS_PATH")
+REAL_MAX_USERS = int(os.environ.get("REAL_MAX_USERS", 25))
+REQUIRED_REAL_COLS = {"useruuid", "latitude", "longitude", "timestamp"}
+
+
+def _default_out_dir():
+    """`test-results/` is this repo's convention for checked-in run output,
+    but a colleague running this file standalone (copied elsewhere, no repo
+    around it) won't have that directory. Use it if present; otherwise fall
+    back to the folder this script itself lives in, rather than creating a
+    `test-results/` wherever the script happens to be invoked from.
+    """
+    env = os.environ.get("STOP_VIZ_OUT_DIR")
+    if env:
+        return Path(env)
+    conventional = Path("test-results")
+    if conventional.is_dir():
+        return conventional
+    return Path(__file__).resolve().parent
+
+
+OUT_DIR = _default_out_dir()
+VIZ_ZOOM_RADIUS_DEG = float(
+    os.environ.get("VIZ_ZOOM_RADIUS_DEG", 0.0008)
+)  # ~90m at this latitude
+
+
+# ===========================================================================
+# Synthetic data
+# ===========================================================================
+HOME = (48.2082, 16.3738)  # lat, lon -- Vienna
+WORK = (48.1867, 16.3378)
+
+
+def _jittered_pings(lat, lon, n, start, step_minutes, spread=0.0002, rng=None):
+    rng = rng or random.Random(0)
+    times = pd.date_range(start, periods=n, freq=f"{step_minutes}min")
+    pts = [
+        (lat + rng.uniform(-spread, spread), lon + rng.uniform(-spread, spread))
+        for _ in range(n)
+    ]
+    return list(times), pts
+
+
+def _transit(p_from, p_to, start, step_minutes=5, n=4):
+    times = pd.date_range(start, periods=n, freq=f"{step_minutes}min")
+    pts = [
+        (p_from[0] + (p_to[0] - p_from[0]) * f, p_from[1] + (p_to[1] - p_from[1]) * f)
+        for f in [0.25, 0.5, 0.75, 1.0]
+    ]
+    return list(times), pts
+
+
+def build_synthetic_pings(seed=0):
+    """One user, 2 days, repeatedly visiting the SAME two real places (home,
+    work): 4 home visits + 2 work visits total, dense raw GPS pings (not
+    pre-aggregated stops -- that's the input shape both detectors actually
+    expect). This is the exact scenario the "same place -> same id/coords?"
+    question is about.
+    """
+    rng = random.Random(seed)
+    times, pts = [], []
+    for day in range(2):
+        base = pd.Timestamp("2024-03-04") + pd.Timedelta(days=day)
+
+        t, p = _jittered_pings(
+            *HOME, n=10, start=base + pd.Timedelta(hours=8), step_minutes=5, rng=rng
+        )
+        times += t
+        pts += p
+        t, p = _transit(HOME, WORK, base + pd.Timedelta(hours=8, minutes=50))
+        times += t
+        pts += p
+        t, p = _jittered_pings(
+            *WORK,
+            n=10,
+            start=base + pd.Timedelta(hours=9, minutes=15),
+            step_minutes=5,
+            rng=rng,
+        )
+        times += t
+        pts += p
+        t, p = _transit(WORK, HOME, base + pd.Timedelta(hours=10, minutes=5))
+        times += t
+        pts += p
+        t, p = _jittered_pings(
+            *HOME,
+            n=8,
+            start=base + pd.Timedelta(hours=10, minutes=45),
+            step_minutes=5,
+            rng=rng,
+        )
+        times += t
+        pts += p
+
+    df = pd.DataFrame(
+        {
+            "useruuid": "synthetic_user",
+            "latitude": [p[0] for p in pts],
+            "longitude": [p[1] for p in pts],
+            "timestamp": [int(t.timestamp()) for t in times],
+        }
+    )
+    return df.sort_values("timestamp").reset_index(drop=True)
+
+
+def build_gap_pings():
+    """3 pings at home, a 3-day data gap, 3 more pings at home. Real-world
+    equivalent: dead battery / poor signal spanning a stop's boundary.
+    """
+    times = list(pd.date_range("2024-01-01 08:00", periods=3, freq="12min30s")) + list(
+        pd.date_range("2024-01-04 08:00", periods=3, freq="12min30s")
+    )
+    pts = [(HOME[0] + i * 1e-6, HOME[1] + i * 1e-6) for i in range(6)]
+    df = pd.DataFrame(
+        {
+            "useruuid": "gap_user",
+            "latitude": [p[0] for p in pts],
+            "longitude": [p[1] for p in pts],
+            "timestamp": [int(t.timestamp()) for t in times],
+        }
+    )
+    return df
+
+
+# ===========================================================================
+# Real data loader
+# ===========================================================================
+def _read_any(path):
+    if os.path.isdir(path):
+        files = sorted(glob.glob(os.path.join(path, "*.parquet")))
+        if not files:
+            raise FileNotFoundError(f"No parquet files found under {path}")
+        return pd.concat([pd.read_parquet(f) for f in files], ignore_index=True)
+    if path.endswith(".parquet"):
+        return pd.read_parquet(path)
+    return pd.read_csv(path)
+
+
+def load_real_pings(path=None, max_users=None, seed=42):
+    path = path or REAL_PINGS_PATH
+    max_users = REAL_MAX_USERS if max_users is None else max_users
+    if not path:
+        raise RuntimeError(
+            "Set REAL_PINGS_PATH to a CSV/parquet (or directory of *.parquet) of "
+            "raw GPS pings with columns: useruuid, latitude, longitude, timestamp "
+            "(unix seconds)."
+        )
+    df = _read_any(path)
+    missing = REQUIRED_REAL_COLS - set(df.columns)
+    if missing:
+        raise ValueError(f"Input is missing required columns: {missing}")
+
+    df = df.sort_values(["useruuid", "timestamp"]).reset_index(drop=True)
+    all_users = sorted(df["useruuid"].unique().tolist())
+    if max_users and max_users < len(all_users):
+        sample = pd.Series(all_users).sample(n=max_users, random_state=seed).tolist()
+        df = df[df["useruuid"].isin(sample)]
+    return df.reset_index(drop=True)
+
+
+# ===========================================================================
+# Detector 1: movingpandas' TrajectoryStopDetector
+# ===========================================================================
+def run_movingpandas_stop_detection(
+    pings_df, max_diameter_m=MPD_MAX_DIAMETER_M, min_duration=MPD_MIN_DURATION
+):
+    """One row per stop, per user. Columns: useruuid, stop_id, start_time,
+    end_time, duration_s, latitude, longitude.
+
+    `stop_id` is `f'{traj_id}_{start_time}'` -- a per-VISIT label, never a
+    location id. Nothing here links two visits to the same physical place.
+    """
+    rows = []
+    for uid, g in pings_df.groupby("useruuid"):
+        g = g.sort_values("timestamp")
+        if len(g) < 2:
+            continue
+        gdf = gpd.GeoDataFrame(
+            {
+                "geometry": [
+                    Point(lon, lat) for lat, lon in zip(g["latitude"], g["longitude"])
+                ]
+            },
+            index=pd.to_datetime(g["timestamp"], unit="s"),
+            crs="EPSG:4326",
+        )
+        traj = mpd.Trajectory(gdf, traj_id=uid)
+        stops = mpd.TrajectoryStopDetector(traj).get_stop_points(
+            max_diameter_m, min_duration
+        )
+        for stop_id, row in stops.iterrows():
+            rows.append(
+                {
+                    "useruuid": uid,
+                    "stop_id": stop_id,
+                    "start_time": row["start_time"],
+                    "end_time": row["end_time"],
+                    "duration_s": row["duration_s"],
+                    "latitude": row["geometry"].y,
+                    "longitude": row["geometry"].x,
+                }
+            )
+    return pd.DataFrame(
+        rows,
+        columns=[
+            "useruuid",
+            "stop_id",
+            "start_time",
+            "end_time",
+            "duration_s",
+            "latitude",
+            "longitude",
+        ],
+    )
+
+
+# ===========================================================================
+# Detector 2: InfoStop
+# ===========================================================================
+def _group_consecutive_stops(labels, times, max_time_between):
+    """Collapse per-ping InfoStop labels into one row per stop: cuts a new
+    group on a label change OR a time gap >= max_time_between, same logic as
+    infostop.postprocess.compute_intervals().
+
+    Deliberately NOT using compute_intervals() itself: its source has a bug
+    where the trailing group is only flushed when it happens to be a -1
+    ("moving") run --
+        if loc_prev == -1: final_trajectory.append([loc_prev, t_start, t_end])
+    -- silently dropping the final real stop otherwise. Confirmed against
+    infostop==<installed version>'s own postprocess.py. Reimplemented here
+    so the comparison in this file doesn't inherit that bug.
+    """
+    labels = np.asarray(labels)
+    times = np.asarray(times)
+    out = []
+    loc_prev, t_start = labels[0], times[0]
+    t_end = t_start
+    for loc, t in zip(labels[1:], times[1:]):
+        if loc == loc_prev and (t - t_end) < max_time_between:
+            t_end = t
+        else:
+            out.append((loc_prev, t_start, t_end))
+            t_start = t
+            t_end = t
+        loc_prev = loc
+    out.append((loc_prev, t_start, t_end))
+    return out
+
+
+def run_infostop_stop_detection(
+    pings_df,
+    r1_m=INFOSTOP_R1_M,
+    r2_m=INFOSTOP_R2_M,
+    min_staying_s=INFOSTOP_MIN_STAYING_S,
+    max_time_between_s=INFOSTOP_MAX_TIME_BETWEEN_S,
+    min_size=INFOSTOP_MIN_SIZE,
+):
+    """One row per stop, per user. Columns: useruuid, loc, start_time,
+    end_time, duration_s, latitude, longitude.
+
+    `loc` IS a location id (Infomap community label, prefixed by useruuid).
+    Every visit sharing a `loc` gets IDENTICAL latitude/longitude, because
+    they come from Infostop.compute_label_medians() -- one canonical value
+    per label, not recomputed per visit.
+
+    Processes each user independently (a loop of single-user fit_predict
+    calls), matching TrajectoryStopDetector's per-trajectory scope. InfoStop
+    also supports a `multiuser` mode that pools stationary points across
+    users before clustering (so users sharing a physical place get the same
+    `loc`) -- not exercised here, to keep this an apples-to-apples,
+    per-trajectory comparison.
+    """
+    if not HAVE_INFOSTOP:
+        raise RuntimeError("pip install infostop to run this")
+
+    rows = []
+    for uid, g in pings_df.groupby("useruuid"):
+        g = g.sort_values("timestamp")
+        if len(g) < min_size:
+            continue
+        t_unix = g["timestamp"].to_numpy(dtype=float)
+        latlon = g[["latitude", "longitude"]].to_numpy(dtype=float)
+        data = np.column_stack([latlon, t_unix])
+
+        model = Infostop(
+            r1=r1_m,
+            r2=r2_m,
+            min_staying_time=min_staying_s,
+            max_time_between=max_time_between_s,
+            min_size=min_size,
+            distance_metric="haversine",
+        )
+        try:
+            labels = model.fit_predict(data)
+        except Exception:
+            continue  # e.g. "No stop events found" -- too few/short stays for this user
+        medians = model.compute_label_medians()
+
+        for loc, t_start, t_end in _group_consecutive_stops(
+            labels, t_unix, max_time_between_s
+        ):
+            if loc == -1:
+                continue  # moving, not a stop
+            lat, lon = medians[loc]
+            rows.append(
+                {
+                    "useruuid": uid,
+                    "loc": f"{uid}_{loc}",
+                    "start_time": pd.to_datetime(int(t_start), unit="s"),
+                    "end_time": pd.to_datetime(int(t_end), unit="s"),
+                    "duration_s": t_end - t_start,
+                    "latitude": lat,
+                    "longitude": lon,
+                }
+            )
+    return pd.DataFrame(
+        rows,
+        columns=[
+            "useruuid",
+            "loc",
+            "start_time",
+            "end_time",
+            "duration_s",
+            "latitude",
+            "longitude",
+        ],
+    )
+
+
+# ===========================================================================
+# Shared assertions
+# ===========================================================================
+def assert_no_location_linking(stops_df):
+    """movingpandas-shaped output: no column links revisits to the same
+    place; `stop_id` is unique per visit by construction."""
+    assert "loc" not in stops_df.columns
+    assert stops_df["stop_id"].is_unique
+
+
+def assert_location_linking(stops_df):
+    """infostop-shaped output: grouping by `loc`, every stop at a given
+    location has identical coordinates (one canonical value per label)."""
+    for _loc, g in stops_df.groupby("loc"):
+        assert g["latitude"].nunique() == 1
+        assert g["longitude"].nunique() == 1
+
+
+def _near(stops_df, place, tol_deg=0.01):
+    return stops_df[
+        (stops_df["latitude"].sub(place[0]).abs() < tol_deg)
+        & (stops_df["longitude"].sub(place[1]).abs() < tol_deg)
+    ]
+
+
+def _readable_pings(pings_df):
+    """Raw pings only carry `timestamp` as unix seconds -- unreadable at a
+    glance. For quick visual inspection (e.g. eyeballing build_gap_pings()'s
+    case study), add a human-readable `datetime` column and, per user, the
+    gap since the previous ping -- the gap column makes a multi-day jump
+    between pings immediately obvious in a print, instead of having to do
+    unix-second arithmetic in your head.
+    """
+    df = pings_df.copy()
+    df["datetime"] = pd.to_datetime(df["timestamp"], unit="s")
+    df["gap_since_prev"] = df.groupby("useruuid")["datetime"].diff()
+    return df[
+        ["useruuid", "datetime", "gap_since_prev", "latitude", "longitude", "timestamp"]
+    ]
+
+
+# ===========================================================================
+# Downstream consequence: feed each detector's own output into
+# MobilityMetricsCalculator, which needs identical coordinates for repeat
+# visits to register as the same location (see point 1/3 above)
+# ===========================================================================
+def stops_to_calculator(stops_df):
+    gdf = gpd.GeoDataFrame(
+        {"useruuid": stops_df["useruuid"].to_numpy()},
+        geometry=[
+            Point(lon, lat)
+            for lat, lon in zip(stops_df["latitude"], stops_df["longitude"])
+        ],
+        index=pd.to_datetime(stops_df["start_time"]),
+        crs="EPSG:4326",
+    )
+    gdf = gdf.sort_index()
+    collection = mpd.TrajectoryCollection(gdf, traj_id_col="useruuid")
+    return mpd.MobilityMetricsCalculator(collection)
+
+
+# ===========================================================================
+# Visualization: one user's raw pings + both detectors' stops, side by side
+# with a zoomed-in panel -- makes the "same place, same/different coords?"
+# question visible at a glance instead of only assertable.
+# ===========================================================================
+_LABEL_OFFSETS = [(8, 8), (8, -14), (-46, 8), (-46, -14), (8, 22), (-46, 22)]
+
+
+def _plot_layer(ax, pings_u, mpd_u, infostop_u):
+    ax.plot(
+        pings_u["longitude"],
+        pings_u["latitude"],
+        "-",
+        color="lightgray",
+        linewidth=0.8,
+        zorder=1,
+    )
+    ax.scatter(
+        pings_u["longitude"],
+        pings_u["latitude"],
+        s=12,
+        color="gray",
+        zorder=1,
+        label="raw pings",
+    )
+
+    if infostop_u is not None and len(infostop_u):
+        ax.scatter(
+            infostop_u["longitude"],
+            infostop_u["latitude"],
+            marker="o",
+            s=220,
+            facecolors="none",
+            edgecolors="steelblue",
+            linewidths=2,
+            zorder=2,
+            label="InfoStop stop (shared coords per loc)",
+        )
+        for _, r in infostop_u.iterrows():
+            ax.annotate(
+                str(r["loc"]).rsplit("_", 1)[-1],
+                (r["longitude"], r["latitude"]),
+                color="steelblue",
+                fontsize=8,
+                fontweight="bold",
+                ha="center",
+                va="center",
+            )
+
+    if len(mpd_u):
+        ax.scatter(
+            mpd_u["longitude"],
+            mpd_u["latitude"],
+            marker="x",
+            s=110,
+            color="crimson",
+            linewidths=2,
+            zorder=3,
+            label="movingpandas stop (own coords per visit)",
+        )
+        for i, (_, r) in enumerate(mpd_u.iterrows()):
+            ax.annotate(
+                r["start_time"].strftime("%m-%d %H:%M"),
+                (r["longitude"], r["latitude"]),
+                color="crimson",
+                fontsize=6,
+                xytext=_LABEL_OFFSETS[i % len(_LABEL_OFFSETS)],
+                textcoords="offset points",
+            )
+
+
+def plot_stop_detection(
+    pings_df,
+    mpd_stops,
+    infostop_stops,
+    user,
+    out_path,
+    zoom_radius_deg=VIZ_ZOOM_RADIUS_DEG,
+):
+    """Save a 2-panel PNG for one user: full trajectory (left) + a zoomed-in
+    panel (right) centered on their most-visited InfoStop location, at a
+    scale small enough to actually see whether movingpandas' per-visit 'x'
+    marks land on top of each other or not, next to InfoStop's single 'o'.
+
+    Returns the saved Path. No-ops (returns None) if matplotlib isn't
+    installed.
+    """
+    if not HAVE_MATPLOTLIB:
+        return None
+
+    pings_u = pings_df[pings_df["useruuid"] == user].sort_values("timestamp")
+    mpd_u = mpd_stops[mpd_stops["useruuid"] == user] if len(mpd_stops) else mpd_stops
+    infostop_u = (
+        infostop_stops[infostop_stops["useruuid"] == user]
+        if infostop_stops is not None and len(infostop_stops)
+        else None
+    )
+
+    fig, (ax_full, ax_zoom) = plt.subplots(1, 2, figsize=(15, 6.5))
+    _plot_layer(ax_full, pings_u, mpd_u, infostop_u)
+    ax_full.set_title("Full trajectory")
+    ax_full.set_xlabel("longitude")
+    ax_full.set_ylabel("latitude")
+    ax_full.set_aspect("equal", adjustable="datalim")
+    ax_full.legend(loc="best", fontsize=8)
+
+    # zoom on whichever place was visited most often (by InfoStop's loc if
+    # available, else just the first movingpandas stop)
+    zoom_center = None
+    if infostop_u is not None and len(infostop_u):
+        top_loc = infostop_u["loc"].value_counts().idxmax()
+        top = infostop_u[infostop_u["loc"] == top_loc].iloc[0]
+        zoom_center = (top["longitude"], top["latitude"])
+    elif len(mpd_u):
+        zoom_center = (mpd_u.iloc[0]["longitude"], mpd_u.iloc[0]["latitude"])
+
+    _plot_layer(ax_zoom, pings_u, mpd_u, infostop_u)
+    if zoom_center is not None:
+        cx, cy = zoom_center
+        # correct the longitude radius for latitude compression (1 deg lon
+        # covers fewer meters than 1 deg lat away from the equator), so a
+        # true equal-aspect square ends up representing an equal-meters box
+        lon_radius_deg = zoom_radius_deg / max(np.cos(np.radians(cy)), 1e-6)
+        ax_zoom.set_xlim(cx - lon_radius_deg, cx + lon_radius_deg)
+        ax_zoom.set_ylim(cy - zoom_radius_deg, cy + zoom_radius_deg)
+    ax_zoom.set_title(
+        f"Zoomed on most-visited place (±{zoom_radius_deg * 111_000:.0f}m)"
+    )
+    ax_zoom.set_xlabel("longitude")
+    ax_zoom.set_ylabel("latitude")
+    # adjustable="box" resizes the subplot box to fit the aspect ratio
+    # instead of silently expanding the xlim/ylim we just set (which
+    # "datalim" does, and which was making the zoom window wider than
+    # requested)
+    ax_zoom.set_aspect("equal", adjustable="box")
+
+    n_mpd = len(mpd_u)
+    # movingpandas has no location id -- the only way to count "unique
+    # locations" is by exact coordinate equality (the same grouping
+    # MobilityMetricsCalculator itself uses, e.g. uncorrelated_entropy()).
+    # Expect this to come out ~= n_mpd, i.e. every visit looks like its own
+    # location -- that IS the finding, not a display bug.
+    n_mpd_unique_locs = (
+        mpd_u[["latitude", "longitude"]].drop_duplicates().shape[0] if n_mpd else 0
+    )
+
+    n_infostop = len(infostop_u) if infostop_u is not None else 0
+    n_infostop_unique_locs = (
+        infostop_u["loc"].nunique() if infostop_u is not None and len(infostop_u) else 0
+    )
+
+    fig.suptitle(
+        f"user={user!r}   |   "
+        f"movingpandas (x): {n_mpd} stops, {n_mpd_unique_locs} unique coord(s)   |   "
+        f"InfoStop (o): {n_infostop} stops, {n_infostop_unique_locs} unique loc(s)"
+    )
+    fig.tight_layout()
+
+    out_path = Path(out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out_path, dpi=150)
+    plt.close(fig)
+    return out_path
+
+
+# ===========================================================================
+# pytest -- synthetic data (always runs)
+# ===========================================================================
+def test_movingpandas_stop_points_have_no_location_id_synthetic():
+    pings = build_synthetic_pings()
+    stops = run_movingpandas_stop_detection(pings)
+    assert len(stops) >= 4
+    assert_no_location_linking(stops)
+
+
+def test_movingpandas_revisits_get_different_coordinates_synthetic():
+    pings = build_synthetic_pings()
+    stops = run_movingpandas_stop_detection(pings)
+    near_home = _near(stops, HOME)
+    assert len(near_home) >= 3, "expected multiple independently-detected home visits"
+    # the whole point: revisits to literally the same place do NOT get
+    # identical coordinates -- each stop's centroid is computed independently
+    assert near_home["latitude"].nunique() > 1
+    assert near_home["longitude"].nunique() > 1
+
+
+@pytest.mark.skipif(not HAVE_INFOSTOP, reason="pip install infostop")
+def test_infostop_links_revisits_to_same_loc_synthetic():
+    pings = build_synthetic_pings()
+    stops = run_infostop_stop_detection(pings)
+    assert "loc" in stops.columns
+    near_home = _near(stops, HOME)
+    assert len(near_home) >= 3
+    # the whole point: InfoStop assigns the SAME loc id, and therefore the
+    # SAME coordinates, to every home visit
+    assert near_home["loc"].nunique() == 1
+    assert_location_linking(stops)
+
+
+@pytest.mark.skipif(not HAVE_MATPLOTLIB, reason="pip install matplotlib")
+def test_visualization_saved_for_one_user_synthetic():
+    pings = build_synthetic_pings()
+    mpd_stops = run_movingpandas_stop_detection(pings)
+    infostop_stops = run_infostop_stop_detection(pings) if HAVE_INFOSTOP else None
+    out = plot_stop_detection(
+        pings,
+        mpd_stops,
+        infostop_stops,
+        "synthetic_user",
+        OUT_DIR / "stop_detection_synthetic_user.png",
+    )
+    assert out is not None and out.exists() and out.stat().st_size > 0
+
+
+def test_movingpandas_silently_spans_data_gap():
+    pings = build_gap_pings()
+    stops = run_movingpandas_stop_detection(
+        pings, max_diameter_m=50, min_duration=timedelta(minutes=20)
+    )
+    assert len(stops) == 1
+    assert (
+        stops.iloc[0]["duration_s"] > 2.5 * 86400
+    ), "should silently count the whole 3-day gap as one stop"
+
+
+@pytest.mark.skipif(not HAVE_INFOSTOP, reason="pip install infostop")
+def test_infostop_does_not_span_data_gap():
+    pings = build_gap_pings()
+    stops = run_infostop_stop_detection(
+        pings,
+        r1_m=50,
+        r2_m=50,
+        min_staying_s=1200,
+        max_time_between_s=86400,
+        min_size=2,
+    )
+    assert len(stops) == 2, "expected the gap to split into two separate stay events"
+    assert (
+        stops["duration_s"] < 3600
+    ).all(), "each side of the gap should be a short, correctly-bounded stop"
+    assert (
+        stops["loc"].nunique() == 1
+    ), "but both sides should still be linked as the same place"
+
+
+def test_downstream_entropy_inflated_without_location_linking():
+    """Practical consequence of points 1-3 above: feed each detector's own
+    stop list straight into movingpandas' own MobilityMetricsCalculator.
+    """
+    pings = build_synthetic_pings()
+
+    mpd_stops = run_movingpandas_stop_detection(pings)
+    # NOTE: MobilityMetricsCalculator returns a plain float (not a Series)
+    # when the collection has only a single trajectory -- see
+    # movingpandas/mobility_metrics.py::uncorrelated_entropy, `if
+    # len(self._trajectories) == 1: return results[...]`.
+    entropy_mpd = stops_to_calculator(mpd_stops).uncorrelated_entropy()
+    # ground truth: only 2 real places were ever visited (home, work) -- but
+    # movingpandas' own stop list has 6 unlinked visits, so this should read
+    # close to log2(6) =~ 2.58, not log2(2) = 1.0
+    assert (
+        entropy_mpd > 1.5
+    ), "expected artificially inflated entropy from unlinked revisits"
+
+    if HAVE_INFOSTOP:
+        infostop_stops = run_infostop_stop_detection(pings)
+        entropy_infostop = stops_to_calculator(infostop_stops).uncorrelated_entropy()
+        assert entropy_infostop < entropy_mpd
+        assert (
+            abs(entropy_infostop - 1.0) < 0.3
+        ), "expected close to log2(2)=1.0 once revisits are linked"
+
+
+# ===========================================================================
+# pytest -- real data (skips cleanly unless REAL_PINGS_PATH is set)
+# ===========================================================================
+pytestmark_real = pytest.mark.skipif(
+    not REAL_PINGS_PATH,
+    reason="REAL_PINGS_PATH not set -- no real ping dataset available yet",
+)
+
+
+@pytestmark_real
+def test_real_movingpandas_stop_list_has_no_location_id():
+    pings = load_real_pings()
+    stops = run_movingpandas_stop_detection(pings)
+    assert len(stops) > 0
+    assert_no_location_linking(stops)
+
+
+@pytestmark_real
+@pytest.mark.skipif(not HAVE_INFOSTOP, reason="pip install infostop")
+def test_real_infostop_locations_have_consistent_coordinates():
+    pings = load_real_pings()
+    stops = run_infostop_stop_detection(pings)
+    assert len(stops) > 0
+    assert_location_linking(stops)
+
+
+@pytestmark_real
+@pytest.mark.skipif(not HAVE_MATPLOTLIB, reason="pip install matplotlib")
+def test_visualization_saved_for_one_user_real():
+    pings = load_real_pings()
+    user = sorted(pings["useruuid"].unique())[0]
+    mpd_stops = run_movingpandas_stop_detection(pings)
+    infostop_stops = run_infostop_stop_detection(pings) if HAVE_INFOSTOP else None
+    out = plot_stop_detection(
+        pings,
+        mpd_stops,
+        infostop_stops,
+        user,
+        OUT_DIR / f"stop_detection_real_{user}.png",
+    )
+    assert out is not None and out.exists() and out.stat().st_size > 0
+
+
+@pytestmark_real
+def test_real_downstream_entropy_comparison_runs():
+    """No ground truth on real data, so this only checks the pipeline runs
+    end to end and produces a per-user entropy inflation ratio >= 1
+    (unlinked can never look LESS diverse than linked, only more or equal) --
+    see the __main__ report below for the actual numbers to eyeball.
+    """
+    pings = load_real_pings()
+    mpd_stops = run_movingpandas_stop_detection(pings)
+    entropy_mpd = stops_to_calculator(mpd_stops).uncorrelated_entropy()
+    # a single sampled user collapses this to a float, not a Series -- see
+    # the _fmt_entropy() note in the __main__ block below. Re-run with
+    # REAL_MAX_USERS >= 2 to exercise the comparison in this test.
+    assert isinstance(entropy_mpd, float) or len(entropy_mpd) > 0
+
+    if HAVE_INFOSTOP and not isinstance(entropy_mpd, float):
+        infostop_stops = run_infostop_stop_detection(pings)
+        entropy_infostop = stops_to_calculator(infostop_stops).uncorrelated_entropy()
+        if not isinstance(entropy_infostop, float):
+            common = entropy_mpd.index.intersection(entropy_infostop.index)
+            assert len(common) > 0
+            assert (entropy_mpd[common] >= entropy_infostop[common] - 1e-9).all()
+
+
+# ===========================================================================
+# Standalone report
+# ===========================================================================
+if __name__ == "__main__":
+    using_real = bool(REAL_PINGS_PATH)
+    print(
+        f"\n{'#' * 70}\n# {'REAL' if using_real else 'SYNTHETIC'} ping data\n{'#' * 70}"
+    )
+    if not HAVE_INFOSTOP:
+        print("\n[!] infostop is not installed -- only running the movingpandas side.")
+        print(
+            "    pip install infostop   to see the actual comparison this file is for.\n"
+        )
+
+    pings = load_real_pings() if using_real else build_synthetic_pings()
+    print(f"\n{len(pings)} pings, {pings['useruuid'].nunique()} user(s)")
+
+    print(
+        f"\n{'=' * 70}\nmovingpandas TrajectoryStopDetector "
+        f"(max_diameter={MPD_MAX_DIAMETER_M}m, min_duration={MPD_MIN_DURATION})\n{'=' * 70}"
+    )
+    mpd_stops = run_movingpandas_stop_detection(pings)
+    print(
+        f"{len(mpd_stops)} stops detected. Columns: {list(mpd_stops.columns)} -- no location id."
+    )
+    print(mpd_stops.head(10).to_string(index=False))
+
+    if not using_real:
+        near_home = _near(mpd_stops, HOME)
+        print(f"\n{len(near_home)} stops detected near HOME={HOME}:")
+        print(near_home[["stop_id", "latitude", "longitude"]].to_string(index=False))
+        print(
+            f"-> {near_home['latitude'].nunique()} distinct latitude values, "
+            f"{near_home['longitude'].nunique()} distinct longitude values among these home visits."
+        )
+        print(
+            "-> CONFIRMS: same physical place, but no shared id, no shared coordinates."
+        )
+
+    if HAVE_INFOSTOP:
+        print(
+            f"\n{'=' * 70}\nInfoStop "
+            f"(r1={INFOSTOP_R1_M}m, r2={INFOSTOP_R2_M}m, min_staying={INFOSTOP_MIN_STAYING_S}s, "
+            f"max_time_between={INFOSTOP_MAX_TIME_BETWEEN_S}s)\n{'=' * 70}"
+        )
+        infostop_stops = run_infostop_stop_detection(pings)
+        print(
+            f"{len(infostop_stops)} stops detected. Columns: {list(infostop_stops.columns)} -- HAS a location id."
+        )
+        print(infostop_stops.head(10).to_string(index=False))
+
+        if not using_real:
+            near_home = _near(infostop_stops, HOME)
+            print(f"\n{len(near_home)} stops detected near HOME={HOME}:")
+            print(near_home[["loc", "latitude", "longitude"]].to_string(index=False))
+            print(
+                f"-> {near_home['loc'].nunique()} distinct loc id(s), "
+                f"{near_home['latitude'].nunique()} distinct latitude value(s)."
+            )
+            print(
+                "-> CONFIRMS: same physical place -> same loc id -> same coordinates."
+            )
+    else:
+        infostop_stops = None
+
+    print(f"\n{'=' * 70}\nVisualization\n{'=' * 70}")
+    if not HAVE_MATPLOTLIB:
+        print(
+            "[!] matplotlib is not installed -- skipping. pip install matplotlib to get a PNG here."
+        )
+    else:
+        viz_user = (
+            "synthetic_user"
+            if not using_real
+            else sorted(pings["useruuid"].unique())[0]
+        )
+        viz_path = OUT_DIR / (
+            "stop_detection_synthetic_user.png"
+            if not using_real
+            else f"stop_detection_real_{viz_user}.png"
+        )
+        saved = plot_stop_detection(
+            pings, mpd_stops, infostop_stops, viz_user, viz_path
+        )
+        print(f"Saved: {saved.resolve()}")
+        print(
+            "Open it to inspect: full trajectory on the left, zoomed-in on the "
+            "most-visited place on the right -- movingpandas' 'x' marks per visit "
+            "vs. InfoStop's single 'o' per location."
+        )
+
+    print(
+        f"\n{'=' * 70}\nGap-length handling ({'real data -- skipped, synthetic-only check' if using_real else '3-day gap, 3 pings each side'})\n{'=' * 70}"
+    )
+    if not using_real:
+        gap_pings = build_gap_pings()
+        print("example case:")
+        print(_readable_pings(gap_pings).to_string(index=False))
+
+        gap_mpd = run_movingpandas_stop_detection(
+            gap_pings, max_diameter_m=50, min_duration=timedelta(minutes=20)
+        )
+        print("movingpandas:")
+        print(gap_mpd.to_string(index=False))
+
+        if HAVE_INFOSTOP:
+            gap_infostop = run_infostop_stop_detection(
+                gap_pings,
+                r1_m=50,
+                r2_m=50,
+                min_staying_s=1200,
+                max_time_between_s=86400,
+                min_size=2,
+            )
+            print("\nInfoStop:")
+            print(gap_infostop.to_string(index=False))
+
+    def _fmt_entropy(x):
+        # MobilityMetricsCalculator returns a plain float for a single-user
+        # collection (synthetic case), a pd.Series (indexed by useruuid)
+        # for multi-user collections (real-data case).
+        return f"{x:.4f}" if isinstance(x, float) else x.round(4).to_string()
+
+    print(
+        f"\n{'=' * 70}\nDownstream: MobilityMetricsCalculator.uncorrelated_entropy()\n{'=' * 70}"
+    )
+    entropy_mpd = stops_to_calculator(mpd_stops).uncorrelated_entropy()
+    print("Fed with movingpandas' own (unlinked) stop list:")
+    print(_fmt_entropy(entropy_mpd))
+    if HAVE_INFOSTOP:
+        entropy_infostop = stops_to_calculator(infostop_stops).uncorrelated_entropy()
+        print("\nFed with InfoStop's (linked) stop list:")
+        print(_fmt_entropy(entropy_infostop))
+        if isinstance(entropy_mpd, float):
+            print(
+                f"\nInflation ratio (movingpandas / infostop): {entropy_mpd / entropy_infostop:.2f}"
+            )
+        else:
+            common = entropy_mpd.index.intersection(entropy_infostop.index)
+            ratio = (
+                entropy_mpd[common] / entropy_infostop[common].replace(0, float("nan"))
+            ).round(2)
+            print("\nInflation ratio (movingpandas / infostop) per user:")
+            print(ratio.to_string())


### PR DESCRIPTION
Adds tests for MobilityMetricsCalculator (cross-validated against independent reference implementations, synthetic + real anonymized stop-sequence data), a stop-detection comparison (movingpandas' TrajectoryStopDetector vs. InfoStop), and a home-detection comparison (home_location() vs. HoWDe). Details in comment on #497