### PR TITLE
Support multiprocessing in generalizers (#486)

### DIFF
--- a/movingpandas/tests/test_trajectory_generalizer.py
+++ b/movingpandas/tests/test_trajectory_generalizer.py
@@ -151,6 +151,39 @@ class TestTrajectoryGeneralizer:
         wkt2 = collection.trajectories[1].to_linestring().wkt
         assert wkt2 == "LINESTRING (10 10, 16 16, 190 19)"
 
+    def test_collection_multiprocessing(self):
+        collection = MinTimeDeltaGeneralizer(self.collection).generalize(
+            tolerance=timedelta(minutes=10), n_processes=2
+        )
+        assert len(collection) == 2
+        wkt1 = collection.trajectories[0].to_linestring().wkt
+        assert wkt1 == "LINESTRING (0 0, 6 6, 9 9)"
+        wkt2 = collection.trajectories[1].to_linestring().wkt
+        assert wkt2 == "LINESTRING (10 10, 16 16, 190 19)"
+
+    def test_collection_multiprocessing_all_cpus(self):
+        collection = MinTimeDeltaGeneralizer(self.collection).generalize(
+            tolerance=timedelta(minutes=10), n_processes=None
+        )
+        assert len(collection) == 2
+
+    def test_collection_multiprocessing_matches_serial(self):
+        cases = [
+            (MinDistanceGeneralizer, 1),
+            (MinTimeDeltaGeneralizer, timedelta(minutes=10)),
+            (MaxDistanceGeneralizer, 1),
+            (DouglasPeuckerGeneralizer, 1),
+            (TopDownTimeRatioGeneralizer, 1),
+        ]
+        for generalizer, tolerance in cases:
+            serial = generalizer(self.collection).generalize(tolerance=tolerance)
+            parallel = generalizer(self.collection).generalize(
+                tolerance=tolerance, n_processes=2
+            )
+            assert len(serial) == len(parallel)
+            for expected, actual in zip(serial.trajectories, parallel.trajectories):
+                assert expected.to_linestring().wkt == actual.to_linestring().wkt
+
 
 class TestTrajectoryGeneralizerNonGeo:
     def setup_method(self):

--- a/movingpandas/trajectory_generalizer.py
+++ b/movingpandas/trajectory_generalizer.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 
 from copy import copy
+from functools import partial
+from multiprocessing import Pool, cpu_count
 from shapely.geometry import LineString, Point
 import pandas as pd
 
@@ -25,7 +27,7 @@ class TrajectoryGeneralizer:
         self.traj = traj
         self.traj_col_name = traj.get_geom_col()
 
-    def generalize(self, tolerance):
+    def generalize(self, tolerance, n_processes=1):
         """
         Generalize the input Trajectory/TrajectoryCollection.
 
@@ -33,6 +35,12 @@ class TrajectoryGeneralizer:
         ----------
         tolerance : any type
             Tolerance threshold, differs by generalizer
+        n_processes : int or None, optional
+            Number of processes to use for computation when generalizing a
+            `TrajectoryCollection` (default: 1). If set to `None`,
+            the number of processes will be set to `os.cpu_count()`,
+            enabling full CPU utilization via multiprocessing. This argument
+            will be ignored when used with a `Trajectory` object.
 
         Returns
         -------
@@ -42,14 +50,42 @@ class TrajectoryGeneralizer:
         if isinstance(self.traj, Trajectory):
             return self._generalize_traj(self.traj, tolerance)
         elif isinstance(self.traj, TrajectoryCollection):
-            return self._generalize_traj_collection(tolerance)
+            if n_processes is None:
+                n_processes = cpu_count()
+
+            if n_processes > 1:
+                return self._generalize_traj_collection_multiprocessing(
+                    tolerance, n_processes
+                )
+            else:
+                return self._generalize_traj_collection(
+                    self.traj.trajectories, tolerance
+                )
         else:
             raise TypeError
 
-    def _generalize_traj_collection(self, tolerance):
+    def _generalize_traj_collection(self, trajs, tolerance):
         generalized = []
-        for traj in self.traj:
+        for traj in trajs:
             generalized.append(self._generalize_traj(traj, tolerance))
+        result = copy(self.traj)
+        result.trajectories = generalized
+        return result
+
+    def _generalize_traj_collection_multiprocessing(self, tolerance, n_processes):
+        from movingpandas.tools._multi_threading import split_list
+
+        p = Pool(n_processes)
+        data = [d for d in split_list(self.traj.trajectories, n_processes)]
+
+        generalize_traj_collection_with_tolerance = partial(
+            self._generalize_traj_collection, tolerance=tolerance
+        )
+
+        generalized = []
+        for g in p.map(generalize_traj_collection_with_tolerance, data):
+            generalized.extend(g)
+
         result = copy(self.traj)
         result.trajectories = generalized
         return result


### PR DESCRIPTION
Closes #486.

`TrajectoryGeneralizer.generalize` now takes an `n_processes` argument with the same semantics as the one `TrajectorySplitter.split` already has: `1` by default, `None` to use `os.cpu_count()`, ignored when the input is a plain `Trajectory` rather than a `TrajectoryCollection`.

Since every generalizer inherits `_generalize_traj_collection` from the base class and only overrides `_generalize_traj`, putting this in the base class covers all of them at once, including the `MinTimeDeltaGeneralizer`, `DouglasPeuckerGeneralizer`, `TopDownTimeRatioGeneralizer` and `MinDistanceGeneralizer` named in the issue, plus `MaxDistanceGeneralizer`.

```python
mpd.DouglasPeuckerGeneralizer(traj_collection).generalize(tolerance=1, n_processes=4)
```

### Implementation note

`_generalize_traj_collection` now takes the trajectory list as a parameter instead of reading `self.traj`, so the same method can be handed one chunk inside a worker. It is private and had no callers outside the base class, so nothing public changed. The chunking uses the existing `movingpandas.tools._multi_threading.split_list` helper and `functools.partial`, mirroring `_split_traj_collection_multiprocessing` so the two read the same way.

### Testing

- `test_collection_multiprocessing` and `test_collection_multiprocessing_all_cpus` cover `n_processes=2` and `n_processes=None`
- `test_collection_multiprocessing_matches_serial` asserts the parallel result is identical to the serial result for all five generalizers
- I checked these tests actually fail if the parallel path is broken, rather than silently passing through the serial branch
- Full suite: 412 passed, 11 skipped
- `black` 22.10.0 and `flake8` 7.3.0 clean, matching the pinned versions in `.pre-commit-config.yaml`

### Disclosure

Written with AI assistance (Claude). Tests and lint were run locally, and the results above are measured rather than assumed. Happy to adjust the API shape if you would rather have `n_processes` on `__init__` like `StopDetector` does instead of on the method like `TrajectorySplitter` does. I followed the splitter because generalizers take their tolerance on the method too.