### PR TITLE
Add DistanceSplitter (#478)

### DIFF
--- a/movingpandas/__init__.py
+++ b/movingpandas/__init__.py
@@ -29,6 +29,7 @@ from .trajectory_splitter import (  # noqa F401
     StopSplitter,
     AngleChangeSplitter,
     ValueChangeSplitter,
+    DistanceSplitter,
 )
 from .trajectory_cleaner import IqrCleaner, OutlierCleaner  # noqa F401
 from .trajectory_stop_detector import TrajectoryStopDetector  # noqa F401

--- a/movingpandas/tests/test_trajectory_splitter.py
+++ b/movingpandas/tests/test_trajectory_splitter.py
@@ -16,6 +16,7 @@ from movingpandas.trajectory_splitter import (
     StopSplitter,
     AngleChangeSplitter,
     ValueChangeSplitter,
+    DistanceSplitter,
 )
 
 
@@ -561,6 +562,100 @@ class TestTrajectorySplitter:
         assert isinstance(split, TrajectoryCollection)
         assert len(split) == 6
         assert split.get_crs() == "EPSG:31256"
+
+    def test_split_by_distance(self):
+        traj = make_traj(
+            [
+                Node(0, 0, day=1),
+                Node(2, 0, day=2),
+                Node(4, 0, day=3),
+                Node(104, 0, day=4),
+                Node(106, 0, day=5),
+            ]
+        )
+        split = DistanceSplitter(traj).split(distance=50)
+        assert isinstance(split, TrajectoryCollection)
+        assert len(split) == 2
+        assert split.trajectories[0].to_linestring().wkt == "LINESTRING (0 0, 2 0, 4 0)"
+        assert split.trajectories[1].to_linestring().wkt == "LINESTRING (104 0, 106 0)"
+        assert [t.id for t in split] == ["1_0", "1_1"]
+
+    def test_split_by_distance_below_threshold_does_not_split(self):
+        traj = make_traj([Node(0, 0, day=1), Node(2, 0, day=2), Node(104, 0, day=3)])
+        split = DistanceSplitter(traj).split(distance=1000)
+        assert len(split) == 1
+        assert (
+            split.trajectories[0].to_linestring().wkt == "LINESTRING (0 0, 2 0, 104 0)"
+        )
+
+    def test_split_by_distance_skips_single_points(self):
+        # the last point is isolated by two big gaps, so it cannot form a segment
+        traj = make_traj(
+            [
+                Node(0, 0, day=1),
+                Node(2, 0, day=2),
+                Node(200, 0, day=3),
+                Node(400, 0, day=4),
+            ]
+        )
+        split = DistanceSplitter(traj).split(distance=50)
+        assert len(split) == 1
+        assert split.trajectories[0].to_linestring().wkt == "LINESTRING (0 0, 2 0)"
+
+    def test_split_by_distance_does_not_alter_df(self):
+        traj = make_traj([Node(0, 0, day=1), Node(2, 0, day=2), Node(104, 0, day=3)])
+        traj_copy = traj.copy()
+        DistanceSplitter(traj).split(distance=50)  # noqa: F841
+        assert_frame_equal(traj.df, traj_copy.df)
+
+    def test_split_by_distance_does_not_leak_distance_column(self):
+        traj = make_traj(
+            [
+                Node(0, 0, day=1),
+                Node(2, 0, day=2),
+                Node(104, 0, day=3),
+                Node(106, 0, day=4),
+            ]
+        )
+        split = DistanceSplitter(traj).split(distance=50)
+        for segment in split:
+            assert traj.get_distance_col() not in segment.df.columns
+
+    def test_split_by_distance_is_crs_aware(self):
+        # one degree is a single CRS unit in a metric CRS but roughly 111 km
+        # in a geographic one, so the same threshold splits only the latter
+        nodes = [Node(0, 0, day=1), Node(1, 0, day=2), Node(2, 0, day=3)]
+        metric = DistanceSplitter(make_traj(nodes, crs=CRS_METRIC)).split(distance=1000)
+        latlon = DistanceSplitter(make_traj(nodes, crs=CRS_LATLON)).split(distance=1000)
+        assert len(metric) == 1
+        assert len(latlon) == 0  # every point is isolated, no segment survives
+
+    def test_split_by_distance_min_length(self):
+        traj = make_traj(
+            [
+                Node(0, 0, day=1),
+                Node(2, 0, day=2),
+                Node(104, 0, day=3),
+                Node(154, 0, day=4),
+            ]
+        )
+        split = DistanceSplitter(traj).split(distance=50, min_length=10)
+        assert len(split) == 1
+        assert split.trajectories[0].to_linestring().wkt == "LINESTRING (104 0, 154 0)"
+
+    def test_split_by_distance_multiprocessing(self):
+        traj = make_traj(
+            [
+                Node(0, 0, day=1),
+                Node(2, 0, day=2),
+                Node(104, 0, day=3),
+                Node(106, 0, day=4),
+            ]
+        )
+        collection = TrajectoryCollection([traj])
+        split = DistanceSplitter(collection).split(distance=50, n_processes=2)
+        assert len(split) == 2
+        assert [t.id for t in split] == ["1_0", "1_1"]
 
 
 class TestTrajectorySplitterNonGeo:

--- a/movingpandas/trajectory_splitter.py
+++ b/movingpandas/trajectory_splitter.py
@@ -391,3 +391,64 @@ class ValueChangeSplitter(TrajectorySplitter):
                     )
                 )
         return TrajectoryCollection(result, min_length=min_length)
+
+
+class DistanceSplitter(TrajectorySplitter):
+    """
+    Split trajectories into subtrajectories whenever there is a gap larger than
+    the specified distance between two consecutive points.
+
+    This is the spatial counterpart to ObservationGapSplitter, which splits on
+    the time between consecutive points instead.
+
+    Parameters
+    ----------
+    distance : numeric
+        Distance threshold between two consecutive points
+        (Distance is calculated using CRS units, except if the CRS is geographic
+        (e.g. EPSG:4326 WGS84) then distance is calculated in metres, unless
+        different units are specified.)
+    min_length : numeric
+        Desired minimum length of trajectories. Shorter trajectories are discarded.
+        (Length is calculated using CRS units, except if the CRS is geographic
+        (e.g. EPSG:4326 WGS84) then length is calculated in metres.)
+    units : str
+        Units in which to calculate the distance between consecutive points
+        (default: CRS units). Ignored if the trajectory already has a distance
+        column. For more info, check the list of supported units at
+        https://movingpandas.org/units
+
+    Examples
+    --------
+    >>> mpd.DistanceSplitter(traj).split(distance=100)
+    """
+
+    def _split_traj(self, traj, distance, min_length=0, units=None):
+        result = []
+        traj = traj.copy()
+        distance_col_name = traj.get_distance_col()
+        added_distance_col = distance_col_name not in traj.df.columns
+        if added_distance_col:
+            traj.add_distance(overwrite=True, units=units)
+
+        temp_df = traj.df.copy()
+        temp_df["gap"] = temp_df[distance_col_name] > distance
+        temp_df["gap"] = temp_df["gap"].apply(lambda x: 1 if x else 0).cumsum()
+        dfs = [group[1] for group in temp_df.groupby(temp_df["gap"])]
+        drop_cols = ["gap"]
+        if added_distance_col:
+            drop_cols.append(distance_col_name)
+        for i, df in enumerate(dfs):
+            df = df.drop(columns=drop_cols)
+            if len(df) > 1:
+                result.append(
+                    Trajectory(
+                        df,
+                        f"{traj.id}_{i}",
+                        traj_id_col=traj.get_traj_id_col(),
+                        x=traj.x,
+                        y=traj.y,
+                        crs=traj.crs,
+                    )
+                )
+        return TrajectoryCollection(result, min_length=min_length)


### PR DESCRIPTION
Closes #478.

Adds the spatial counterpart to `ObservationGapSplitter`: split a trajectory wherever the distance between two consecutive points exceeds a threshold, rather than the time between them.

```python
mpd.DistanceSplitter(traj).split(distance=100)
```

The original requester offered to implement this over a year ago and it never landed, so I picked it up. Structure mirrors `ObservationGapSplitter` exactly, so `n_processes`, `min_length` and the rest of `TrajectorySplitter.split` work without any extra wiring.

### Design notes

- **CRS aware via the existing machinery.** Distances come from `Trajectory.add_distance`, so the behaviour matches the rest of the library: metres for geographic CRS, CRS units otherwise, with an optional `units` argument.
- **Respects an existing distance column.** If the trajectory already carries one, it is used as is rather than recomputed.
- **Cleans up after itself.** A distance column added by the splitter is dropped again, so the resulting segments do not gain a column the caller never asked for. There is a test for this.

The issue suggested naming the parameter `distance_meters`. I used `distance` plus the standard `units` argument instead, to match `MinDistanceGeneralizer` and `add_distance`, since the value is not always in metres. Easy to change if you would rather have the explicit name.

### Testing

Eight new tests: basic split, threshold above the largest gap, isolated points that cannot form a segment, `min_length`, the df not being mutated, the distance column not leaking into results, `n_processes=2`, and a CRS awareness test where one degree is a single unit in a metric CRS but roughly 111 km in a geographic one, so the same threshold splits only the latter.

Full suite: 423 passed, 11 skipped. `black` 22.10.0 and `flake8` 7.3.0 clean at the pinned versions.

### Disclosure

Written with AI assistance (Claude). Tests and lint were run locally and the numbers above are actual output.