### PR TITLE
Optionally set parent on split results (#472)

### DIFF
--- a/movingpandas/tests/test_trajectory_splitter.py
+++ b/movingpandas/tests/test_trajectory_splitter.py
@@ -562,6 +562,49 @@ class TestTrajectorySplitter:
         assert len(split) == 6
         assert split.get_crs() == "EPSG:31256"
 
+    def test_split_has_no_parent_by_default(self):
+        traj = make_traj([Node(), Node(minute=1), Node(minute=5), Node(minute=6)])
+        split = ObservationGapSplitter(traj).split(gap=timedelta(seconds=120))
+        assert len(split) == 2
+        for segment in split:
+            assert segment.parent is None
+
+    def test_split_with_parent(self):
+        traj = make_traj([Node(), Node(minute=1), Node(minute=5), Node(minute=6)])
+        split = ObservationGapSplitter(traj).split(
+            gap=timedelta(seconds=120), parent=True
+        )
+        assert len(split) == 2
+        for segment in split:
+            assert segment.parent is traj
+
+    def test_split_collection_with_parent(self):
+        split = ObservationGapSplitter(self.collection).split(
+            gap=timedelta(minutes=30), parent=True
+        )
+        assert len(split) > 0
+        sources = {t.id: t for t in self.collection}
+        for segment in split:
+            assert segment.parent is not None
+            # segment ids are "<parent id>_<n>"
+            assert segment.parent is sources[segment.parent.id]
+            assert str(segment.id).startswith(f"{segment.parent.id}_")
+
+    def test_split_collection_without_parent_by_default(self):
+        split = ObservationGapSplitter(self.collection).split(gap=timedelta(minutes=30))
+        assert len(split) > 0
+        for segment in split:
+            assert segment.parent is None
+
+    def test_split_collection_with_parent_multiprocessing(self):
+        split = ObservationGapSplitter(self.collection).split(
+            gap=timedelta(minutes=30), parent=True, n_processes=2
+        )
+        assert len(split) > 0
+        for segment in split:
+            assert segment.parent is not None
+            assert str(segment.id).startswith(f"{segment.parent.id}_")
+
 
 class TestTrajectorySplitterNonGeo:
     def setup_method(self):

--- a/movingpandas/trajectory_splitter.py
+++ b/movingpandas/trajectory_splitter.py
@@ -31,7 +31,7 @@ class TrajectorySplitter:
         """
         self.traj = traj
 
-    def split(self, n_processes=1, **kwargs):
+    def split(self, n_processes=1, parent=False, **kwargs):
         """
         Split the input Trajectory/TrajectoryCollection.
 
@@ -43,6 +43,13 @@ class TrajectorySplitter:
             the number of processes will be set to `os.cpu_count()`,
             enabling full CPU utilization via multiprocessing. This argument
             will be ignored when used with a `Trajectory` object.
+        parent : bool, optional
+            Whether to set the `parent` attribute of each resulting segment to
+            the trajectory it was split from (default: False), the way
+            `Trajectory.clip` already does. Off by default because holding on
+            to the source trajectory keeps its DataFrame alive for as long as
+            any of its segments are, and because it makes segments compare
+            unequal to otherwise identical parentless trajectories.
         kwargs : any type
             Split parameters, differs by splitter
 
@@ -52,32 +59,40 @@ class TrajectorySplitter:
             Split trajectories
         """
         if isinstance(self.traj, Trajectory):
-            return self._split_traj(self.traj, **kwargs)
+            result = self._split_traj(self.traj, **kwargs)
+            if parent:
+                for segment in result:
+                    segment.parent = self.traj
+            return result
         elif isinstance(self.traj, TrajectoryCollection):
             if n_processes is None:
                 n_processes = cpu_count()
 
             if n_processes > 1:
                 return self._split_traj_collection_multiprocessing(
-                    n_processes, **kwargs
+                    n_processes, parent=parent, **kwargs
                 )
             else:
-                return self._split_traj_collection(self.traj, **kwargs)
+                return self._split_traj_collection(self.traj, parent=parent, **kwargs)
         else:
             raise TypeError
 
-    def _split_traj_collection(self, trajs, **kwargs):
+    def _split_traj_collection(self, trajs, parent=False, **kwargs):
         trips = []
 
         for traj in trajs:
             for x in self._split_traj(traj, **kwargs):
                 if x.get_length() > self.traj.min_length:
+                    if parent:
+                        x.parent = traj
                     trips.append(x)
         result = copy(self.traj)
         result.trajectories = trips
         return result
 
-    def _split_traj_collection_multiprocessing(self, n_processes, **kwargs):
+    def _split_traj_collection_multiprocessing(
+        self, n_processes, parent=False, **kwargs
+    ):
         from movingpandas.tools._multi_threading import split_list
 
         p = Pool(n_processes)
@@ -85,7 +100,7 @@ class TrajectorySplitter:
         data = [d for d in data]
 
         split_traj_collection_with_kwargs = partial(
-            self._split_traj_collection, **kwargs
+            self._split_traj_collection, parent=parent, **kwargs
         )
 
         splits = []


### PR DESCRIPTION
Closes #472.

`Trajectory.clip` already records which trajectory each segment came from (`segment.parent = traj` in `overlay.py`), but the splitters never did, so split results always came back with `parent=None`.

`split()` now takes a `parent` argument:

```python
ObservationGapSplitter(traj).split(gap=timedelta(hours=1), parent=True)
```

Setting it in `_split_traj_collection` rather than inside each `_split_traj` means all seven splitters pick it up without any per-splitter changes, and it works on the single `Trajectory` path and the multiprocessing path too.

### Why it defaults to off

The issue said "maybe make it optional to save memory", and there turned out to be two reasons to leave it off:

1. **Memory**, as you suspected. Holding the source trajectory keeps its DataFrame alive for as long as any of its segments is. With multiprocessing it is worse, because the parent is pickled back out of each worker along with every segment.
2. **Equality.** `Trajectory.__eq__` compares `parent`, so a segment with a parent no longer compares equal to an otherwise identical parentless trajectory. Turning this on by default would have changed the result of existing comparisons and broken a number of the current splitter tests, which assert against `make_traj(..., id="1_0")` with no parent.

Point 2 is the one I would not want to decide on your behalf, so the default keeps existing behaviour exactly. Flipping it is a one line change if you would rather have it on and update the tests.

### Testing

Five new tests: parent is `None` by default for both a `Trajectory` and a `TrajectoryCollection`, is the source trajectory when requested, is the *correct* source for each segment when splitting a collection, and survives multiprocessing. The collection test checks identity against the actual source trajectory rather than just non-`None`; the multiprocessing test checks the id relationship instead, since an unpickled parent is necessarily a different object.

All 35 pre-existing splitter tests pass unchanged, which is the backward compatibility check. Full suite: 414 passed, 11 skipped. `black` 22.10.0 and `flake8` 7.3.0 clean at the pinned versions.

### Disclosure

Written with AI assistance (Claude). Tests and lint were run locally and the numbers are actual output.