### PR TITLE
Fix hvplot ignoring vmin/vmax in TrajectoryPlotter

### DIFF
--- a/movingpandas/tests/test_trajectory_plotter.py
+++ b/movingpandas/tests/test_trajectory_plotter.py
@@ -37,6 +37,14 @@ class TestTrajectoryCollection:
         assert min_value == 2
         assert max_value == 10
 
+    def test_get_min_max_values_respects_vmin_vmax(self):
+        self.plotter = _TrajectoryPlotter(
+            self.collection, column="val", vmin=1, vmax=20
+        )
+        min_value, max_value = self.plotter.get_min_max_values()
+        assert min_value == 1
+        assert max_value == 20
+
 
 class TestTrajectoryCollectionNonGeo:
     def setup_method(self):

--- a/movingpandas/trajectory_plotter.py
+++ b/movingpandas/trajectory_plotter.py
@@ -51,7 +51,7 @@ class _TrajectoryPlotter:
         max_value = self.data.get_max(self.column)
         self.min_value = self.kwargs.pop("vmin", min_value)
         self.max_value = self.kwargs.pop("vmax", max_value)
-        return min_value, max_value
+        return self.min_value, self.max_value
 
     def plot(self):
         if not self.ax:


### PR DESCRIPTION
## What
Make `_TrajectoryPlotter.get_min_max_values()` return the user-supplied `vmin`/`vmax` so `hvplot(c=..., vmin=, vmax=)` actually clips the colour scale.

## Why / evidence
Reported in #474. `get_min_max_values()` pops `vmin`/`vmax` from kwargs into `self.min_value`/`self.max_value` (falling back to the data min/max), but then `return min_value, max_value` returns the *raw data* values. `preprocess_data()` uses that return value to set `self.clim`, which is what every hvplot path passes as `clim=`. Result: `vmin`/`vmax` are silently ignored for interactive plots and the colour range is always the data range.

Reproduced on `main` with a 4-point TrajectoryCollection (`val` range 2-9):

```python
p = _TrajectoryPlotter(tc, column="val", vmin=1, vmax=20)
p.preprocess_data()
print(p.clim)   # -> (2, 9)   expected (1, 20)
```

## Change
- `trajectory_plotter.py`: `get_min_max_values()` now returns `self.min_value, self.max_value`.
- `tests/test_trajectory_plotter.py`: add `test_get_min_max_values_respects_vmin_vmax`.

The matplotlib path already used `self.min_value`/`self.max_value` directly and is unaffected.

## Verified
```
$ pytest movingpandas/tests/test_trajectory_plotter.py -q
....                                                                     [100%]
4 passed
$ flake8 movingpandas/trajectory_plotter.py movingpandas/tests/test_trajectory_plotter.py
(exit 0)
```
Repro script now prints `clim: (1, 20)`. Existing `test_get_min_max_values*` (no vmin/vmax) still pass - return value is unchanged when the user passes nothing.

Fixes #474
